### PR TITLE
build(pnpm): move devEngines onFail to warn so npm and action-setup both work

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "packageManager": {
       "name": "pnpm",
       "version": "^11.0.0",
-      "onFail": "error"
+      "onFail": "warn"
     }
   },
   "homepage": "https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46",


### PR DESCRIPTION
Follow-up on [RSRMID-3008](https://centralnic.atlassian.net/browse/RSRMID-3008). Fixes a live breakage the strict form introduced.

> **Supersedes the array-form approach** this PR originally carried — see the discussion below. Net diff against the tracked branch is now **one word**.

## The constraint

Two tools read `devEngines.packageManager` and they disagree about what may appear in it:

| | `npm` (publishing) | `pnpm/action-setup` (CI install) |
|---|---|---|
| object, `onFail: error` | ❌ `EBADDEVENGINES` | ✅ |
| array (pnpm + npm) | ✅ `ENEEDAUTH` | ❌ `No pnpm version is specified` |
| **object, `onFail: warn`** | ✅ `ENEEDAUTH` | ✅ |

**npm** enforces the declaration against *itself*, on every command — not just install. With `error`, even `npm whoami` exits `EBADDEVENGINES`, and `@semantic-release/npm` calls exactly that in `verifyConditions` before it can authenticate. That made every publishing repository unreleasable the moment the field was adopted.

**pnpm/action-setup** reads only the object form. Its check is literally:

```js
if (s?.packageManager?.name === "pnpm" && s.packageManager.version) return s.packageManager.version;
```

An array has no `.name`, so it falls through and nothing installs. True as of v6.0.10, the latest.

So the object form is forced by action-setup, and `warn` is forced by npm. No single value keeps `error`.

## What it costs

Stated plainly, and recorded in `node-policy.conf` rather than left implicit: a container or runner on a pnpm outside the range now proceeds with a `[WARN]` instead of stopping. The weekly `node-policy-drift.yml` still catches a *manifest* that disagrees with policy; nothing now catches a *runtime* on the wrong pnpm.

Restoring `error` requires the publishing repositories to stop invoking npm to publish — filed separately.

## Verification

All three rows above were run, not assumed. No lockfile change: the pnpm entry’s name and version are untouched.

[RSRMID-3008]: https://centralnic.atlassian.net/browse/RSRMID-3008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ