### PR TITLE
chore(deps): require a 24-hour minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,15 @@ allowBuilds:
 overrides:
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
   serialize-javascript@<=7.0.2: '>=7.0.3'
-minimumReleaseAge: 0
+
+# Nothing here is installed until it is at least a day old. This is a supply-chain
+# control, not a tidiness rule: the npm attacks that actually hurt people publish a
+# compromised version of a real package and rely on automation to pull it into a build
+# within minutes. Setting this to 0 to make a red build go green removes the protection
+# at exactly the moment it is worth the most — wait instead.
+#
+# 1440 minutes is pnpm's default, declared explicitly so that it is a decision which can
+# be reported as drift rather than one inherited silently. One value across every
+# rtldev-middleware repository, enforced by node-policy.sh in the workspace repository.
+# (RSRMID-3018)
+minimumReleaseAge: 1440


### PR DESCRIPTION
Part of [RSRMID-3018](https://centralnic.atlassian.net/browse/RSRMID-3018).

## Why

The daily dependency refresh resolved lockfiles with a 30-minute `minimumReleaseAge`
while every other install applied pnpm's default of 24 hours. It therefore committed
lockfiles that every consumer then rejected with
`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` for up to a day, and any release triggered in
that window failed through no fault of the change that triggered it. The offending
packages rotated with each run, which made a standing conflict between two jobs look
like a transient.

The escape hatch had been applied unevenly across the organisation: three repositories
set `minimumReleaseAge: 0`, two carried hand-maintained `minimumReleaseAgeExclude`
allowlists that had already rotted (both pinned
`@team-internet/semantic-release-plugins@1.0.6` by exact version long after that package
moved to 2.3.1, so they no longer matched anything they were written to cover), and the
rest inherited the default and broke.

## What this does

Declares one value — 1440 minutes — here and in every other `rtldev-middleware`
repository, and retires the allowlists.

1440 is pnpm's own default, named explicitly rather than inherited so that it is a
decision which can be reported as drift when it changes. `0` is deliberately not the
answer: this is a supply-chain control, and the reasoning is written into the file so
that the next person under time pressure does not reach for it to make a build go green.

The companion change in `rtldev-middleware-shareable-workflows` deletes the refresh
job's own `--config.minimumReleaseAge=30` rather than correcting the number, so that
both `pnpm` and `npm-check-updates` read this file instead. That makes the producer and
the consumer of the lockfile the same threshold by construction — and since the
constraint is "published before now minus the threshold", and now only moves forward, a
lockfile the refresh resolves can never be too fresh for a later install.

Enforced from here on by `scripts/node-policy.sh` in the workspace repository, which
also forbids `minimumReleaseAgeExclude`.

## Verification

`pnpm install --frozen-lockfile` passes in this repository under the new threshold.

[RSRMID-3018]: https://centralnic.atlassian.net/browse/RSRMID-3018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ