### PR TITLE
build(devcontainer): add a devcontainer built on the devbase Feature

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,6 @@
+# The devcontainer metadata is read by the CLI, not by the image build, so
+# keeping it out of the build context avoids a needless cache invalidation on
+# every edit to devcontainer.json.
+devcontainer.json
+devcontainer-lock.json
+env-info.conf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+# Development image for this repository.
+#
+# Deliberately thin, and meant to stay that way. The packages, timezone, zsh
+# configuration and commitizen setup that a hand-written devcontainer would put
+# here all come from the devbase Feature:
+# https://github.com/centralnicgroup-opensource/rtldev-middleware-devcontainer-features
+#
+# Node arrives with devbase too, which declares the node Feature at LTS as its own
+# dependency — so this file pins no language image.
+#
+# Add a layer here only for something the Feature cannot express: a system library
+# a native module needs to compile, an image-level config file. If what you are
+# about to add is shared behaviour rather than this repository's own, it belongs in
+# the Feature instead.
+
+FROM mcr.microsoft.com/devcontainers/base:2-ubuntu-24.04
+
+# No ENV DEBIAN_FRONTEND here on purpose: set at image level it persists into the
+# running container, so an interactive `apt` in a shell session also loses its
+# frontend. A layer that needs it sets it for itself.
+ENV TERM=xterm-256color

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,70 @@
+{
+  // Everything shared with the other RTLDEV middleware repositories lives in the
+  // devbase Feature, not here: zsh with the team prompt, commitizen, pnpm at the
+  // version package.json declares, Node LTS, the GitHub CLI, the Claude Code CLI,
+  // the gh credential helper, persistent shell history, dependency installation,
+  // the shared VS Code extension set and the on-attach toolchain banner.
+  //
+  // This repository is written in the language devbase already brings, so what is left here is only what a Feature cannot set: the name, the workspace paths, the remote user, initializeCommand and the host mounts.
+  //
+  // Feature options and troubleshooting:
+  // https://github.com/centralnicgroup-opensource/rtldev-middleware-devcontainer-features
+  "name": "dstack-idna-uts46",
+  "build": {
+    "context": ".",
+    "dockerfile": "Dockerfile"
+  },
+
+  // localWorkspaceFolderBasename is the repository directory name, so these two
+  // need no editing per repository and cannot drift out of sync with it.
+  "workspaceMount": "source=${localWorkspaceFolder},target=/usr/share/${localWorkspaceFolderBasename},type=bind,consistency=cached",
+  "workspaceFolder": "/usr/share/${localWorkspaceFolderBasename}",
+  "shutdownAction": "stopContainer",
+
+  // Host-side preflight for the binds at the bottom of this file: Docker creates
+  // a missing bind source itself, as a root-owned *directory*. For ~/.ssh and
+  // ~/.claude that yields a directory nobody in the container can write to; for
+  // ~/.gitconfig it yields a directory where git expects a file, on the host too.
+  // Runs on the host, so it cannot move into a Feature.
+  "initializeCommand": {
+    "claude-state": "mkdir -p ${localEnv:HOME}/.claude",
+    "ssh-dir": "mkdir -p ${localEnv:HOME}/.ssh",
+    "gitconfig": "touch ${localEnv:HOME}/.gitconfig"
+  },
+
+  "features": {
+    // Node LTS, the GitHub CLI and the Claude Code CLI are devbase's own
+    // dependencies, so none of the three is listed here. Do NOT re-declare
+    // node:2 to change its version: one Feature id with two option sets counts
+    // as two Features under the spec's equality rule, so Node would install
+    // twice into the same nvm path. A repository that genuinely needs another
+    // major raises it against devbase.
+    "ghcr.io/centralnicgroup-opensource/rtldev-middleware-devcontainer-features/devbase:1": {}
+  },
+
+  // No "customizations" block on purpose: devbase contributes the whole shared
+  // VS Code layer — GitHub Actions, GitHub PRs, Remote Containers, Containers,
+  // both Claude extensions, shellcheck / shell-format / vscode-yaml with their
+  // settings, and the zsh terminal profile. Add one back only for an extension
+  // specific to this repository.
+
+  "remoteUser": "vscode",
+
+  // .ssh and .gitconfig make git work as it does on the host; /WSL_USER is what
+  // devbase's history persistence reads; .claude carries the Claude Code session
+  // state. Kept here because a Feature cannot mount.
+  //
+  // ${localEnv:HOME}${localEnv:USERPROFILE} resolves to whichever of the two the
+  // host defines. On a host defining *both* it resolves to neither and Docker
+  // mounts an empty directory; devbase reports that on post-create rather than
+  // silently losing history.
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE},target=/WSL_USER,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
+  ]
+
+  // No postCreateCommand: devbase installs pnpm, the global packages and this
+  // repository's dependencies, and seeds .env from .env.example.
+}

--- a/.devcontainer/env-info.conf
+++ b/.devcontainer/env-info.conf
@@ -1,0 +1,9 @@
+# Drives the on-attach banner the devbase Feature prints. Sourced as shell, so
+# quote values containing spaces. Every setting is optional; see
+# https://github.com/centralnicgroup-opensource/rtldev-middleware-devcontainer-features
+
+TITLE="IDNA-UTS46 - development environment"
+
+SHOW_NODE=true
+
+NODE_DEPS="rollup mocha eslint prettier"


### PR DESCRIPTION
[RSRMID-3020](https://centralnic.atlassian.net/browse/RSRMID-3020). This repository had no devcontainer at all, so everyone working on it built their own environment by hand.

It now gets the frame the SDKs use after RSRMID-3019: a single container from a thin Dockerfile, with the `devbase` Feature carrying everything shared — zsh with the team prompt, commitizen, pnpm at the version `package.json` declares, the `gh` credential helper, persistent shell history, dependency installation, the shared VS Code extension set and the on-attach toolchain banner.

Because Node LTS, the GitHub CLI and the Claude Code CLI are `devbase`'s own dependencies, the feature list names `devbase` and nothing else, and there is no `customizations` block — the shared extension set is the Feature's. The whole frame is four files, three of which are boilerplate.

The host mounts (`~/.ssh`, `~/.gitconfig`, `~/.claude`, and the host home at `/WSL_USER`) are what make git, Claude Code and shell history behave in the container as they do on the host.

## Verification

Not rebuilt — no Docker daemon in the workspace this was prepared from. On the first rebuild, check that the prompt renders, `devbase-env-info` reports Node and the dependency versions, `pnpm test` and `pnpm lint` run, and `cz --version` works. That rebuild also writes a `devcontainer-lock.json`, which should then be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-3020]: https://centralnic.atlassian.net/browse/RSRMID-3020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ