### PR TITLE
feat(cli): command line interface, plus docs/tooling housekeeping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      include: "scope"
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'

--- a/.github/workflows/daily-node-dependency-refresh.yml
+++ b/.github/workflows/daily-node-dependency-refresh.yml
@@ -2,7 +2,7 @@ name: Daily Node dependency refresh
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: '17 3 * * *'
   workflow_dispatch:
 
 permissions:
@@ -22,4 +22,4 @@ jobs:
       # Empty, so pnpm/action-setup resolves the version from
       # `devEngines.packageManager` in package.json rather than installing whatever
       # pnpm is newest. (RSRMID-3008)
-      pnpm-version: ""
+      pnpm-version: ''

--- a/.github/workflows/daily-node-dependency-refresh.yml
+++ b/.github/workflows/daily-node-dependency-refresh.yml
@@ -18,7 +18,7 @@ jobs:
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/daily-node-dependency-refresh.yml@main
     secrets: inherit
     with:
-      base-ref: master
+      base-ref: main
       # Empty, so pnpm/action-setup resolves the version from
       # `devEngines.packageManager` in package.json rather than installing whatever
       # pnpm is newest. (RSRMID-3008)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,105 @@
+name: Quality
+'on':
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Language-agnostic on purpose — it checks the things every repository has regardless of
+# what it is written in: Markdown/JSON/YAML formatting, workflow syntax, and shell
+# scripts. The language-specific analysers live in test.yml, which delegates to the
+# shared workflow. A repository wants both.
+jobs:
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # No `version:` input, deliberately — the action then resolves the version from
+      # `devEngines.packageManager` in package.json, so CI runs a pnpm inside the range
+      # this repository declares rather than whatever pnpm released most recently.
+      # Passing a version here as well is a hard error: the action refuses two
+      # disagreeing declarations. (RSRMID-3008)
+      #
+      # It must come before setup-node, which needs pnpm on PATH to resolve `cache: pnpm`.
+      - uses: pnpm/action-setup@v6.0.10
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      # Installing rather than `npx --yes prettier@3` — that fetched whatever prettier 3
+      # happened to be newest, so CI could disagree with every developer's checkout over
+      # formatting nobody had changed. The lockfile pins one version for both. It also
+      # takes npm off the CI path entirely, which is the point: we install with pnpm.
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      # Gated, not advisory: unformatted Markdown should be a red build rather than a
+      # local nag that everyone learns to ignore.
+      - name: Check formatting
+        run: pnpm prettier
+
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-check
+          fail_level: error
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # `git ls-files` rather than `find`, so this lints only *tracked* files and needs
+      # no prune list. The generated scripts that are not ours to lint live in .husky/_/
+      # (written by husky on install; its husky.sh has no shebang, so it fails SC2148)
+      # and node_modules/ — both untracked, so there is nothing to forget to exclude when
+      # a third one appears.
+      #
+      # .husky/pre-commit is named explicitly because it has no `.sh` extension.
+      # -z | xargs -0 survives paths with spaces, and `--no-run-if-empty` makes
+      # "this repository has no other shell scripts" a pass instead of a shellcheck
+      # invoked with no arguments (which exits 3 with a usage dump).
+      - name: ShellCheck
+        run: |
+          git ls-files -z '*.sh' .husky/pre-commit \
+            | xargs -0 --no-run-if-empty shellcheck --severity=warning
+          echo "ShellCheck completed."
+
+  ci-success:
+    name: 'Quality: completed'
+    needs: [prettier, actionlint, shellcheck]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        # Two things here are load-bearing:
+        #
+        # Single quotes inside the expression, because GitHub expressions have no
+        # double-quoted string literal — `join(needs.*.result, " ")` is not a style slip
+        # but a syntax error, and it makes the whole file "Invalid workflow file", so the
+        # gate never runs at all rather than running and passing.
+        #
+        # `tr` splits the space-joined results onto one line each. Against a single line,
+        # `grep -vw success` selects nothing as long as the word appears anywhere, so
+        # "success failure success" would report green — the one outcome this job exists
+        # to catch.
+        run: |
+          if echo '${{ join(needs.*.result, ' ') }}' | tr ' ' '\n' | grep -qvw success; then
+            echo "One or more quality jobs failed: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       # Empty, so pnpm/action-setup resolves the version from
       # `devEngines.packageManager` in package.json rather than installing whatever
       # pnpm is newest. (RSRMID-3008)
-      pnpm-version: ""
+      pnpm-version: ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
       # Empty, so pnpm/action-setup resolves the version from
       # `devEngines.packageManager` in package.json rather than installing whatever
       # pnpm is newest. (RSRMID-3008)
-      pnpm-version: ""
+      pnpm-version: ''

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# Skip hooks in CI — semantic-release's own commits would otherwise trigger
+# lint-staged, which reformats files it has no business touching mid-release.
+[ "$CI" = "true" ] && exit 0
+pnpm exec lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,19 @@
-coverage
-.nyc_output
-dist
-.github
+node_modules/
+.pnpm-store/
+coverage/
+.nyc_output/
+dist/
+pnpm-lock.yaml
+
+# Copied into test/ by the `preserve` script out of dist/ and node_modules/. Generated,
+# gitignored, and not ours to format.
+test/index.mjs
+test/index.bundle.js
+test/mocha.css
+
+# Generated and owned by semantic-release (@semantic-release/changelog), which commits
+# it through @semantic-release/git and therefore never passes it through lint-staged. So
+# the copy in git is unformatted, and any human commit touching the file would make
+# lint-staged reflow the whole changelog — hundreds of lines of churn to edit two. Left
+# alone instead.
 HISTORY.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,81 +5,108 @@ email, or any other method with the owners of this repository before making a ch
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
-## Pull Request Process
+## Development
 
-Every change goes through a pull request, there are no direct pushes to `master`.
+The repository ships a devcontainer, so **Reopen in Container** is the supported
+setup — it brings the toolchain and the linters. Working outside it is possible but
+unsupported, and version skew against CI is on you.
 
-1. Create a branch off `master`, named after what it does, e.g. `feat/cli` or `fix/transitional-detection`.
-2. Keep a pull request focused on one topic. Unrelated changes belong in their own pull request.
-3. Run the checks locally before you push:
+Run the repository's lint and test scripts before opening a pull request. The shared
+CI workflows run the same ones, so a green local run is a green build:
 
-   ```bash
-   pnpm install
-   pnpm test    # mocha test suite
-   pnpm lint    # eslint
-   ```
-
-   Formatting is handled by prettier and runs automatically on the staged files via lint-staged.
-
-4. Write your commit messages in the format described below. The release is derived from them, so this is not cosmetic.
-5. Open the pull request against `master` and describe what changed, why, and how you verified it.
-6. Once a maintainer approves and merges, semantic-release publishes the new version to npm, tags it, updates `HISTORY.md` and creates the github release. Nothing is released by hand.
-
-## Commit Messages
-
-Releases are fully automated with [semantic-release](https://github.com/semantic-release/semantic-release), which derives the next version number from the commit messages that land on `master`. We follow the Angular convention:
-
-```
-<type>(<scope>): <short summary>
-
-<optional body>
-
-<optional footer>
+```bash
+pnpm install
+pnpm test    # mocha test suite
+pnpm lint    # eslint
 ```
 
-- **type** — one of the types listed below, lowercase.
-- **scope** — optional, the part of the package you touched, e.g. `cli`, `deps`, `toAscii`.
-- **short summary** — imperative mood ("add", not "added" or "adds"), no capital first letter, no trailing period.
+## Commit messages
 
-### Types and their effect on the release
+[Conventional Commits](https://www.conventionalcommits.org/) with a **mandatory
+scope**:
 
-| **Type**   | **Use for**                                          | **Release**           |
-| ---------- | ---------------------------------------------------- | --------------------- |
-| `feat`     | a new feature                                        | minor (1.2.3 → 1.3.0) |
-| `fix`      | a bug fix                                            | patch (1.2.3 → 1.2.4) |
-| `perf`     | a change that improves performance                   | patch                 |
-| `revert`   | reverting an earlier commit                          | patch                 |
-| `docs`     | documentation only                                   | none                  |
-| `refactor` | a change that neither fixes a bug nor adds a feature | none                  |
-| `test`     | adding or correcting tests                           | none                  |
-| `build`    | build system, bundling or dependencies               | none                  |
-| `ci`       | CI configuration and workflows                       | none                  |
-| `style`    | formatting only, no change in behavior               | none                  |
-| `chore`    | maintenance that fits nowhere else                   | none                  |
+```text
+<type>(<scope>): <summary>
+```
 
-A type that triggers no release still shows up in the repository history, it just does not produce a new version on its own.
+- **type** — one of the types in the table below, lowercase.
+- **scope** — the part of the package you touched, e.g. `cli`, `deps`, `toAscii`.
+- **summary** — imperative mood ("add", not "added" or "adds"), no capital first
+  letter, no trailing period.
+
+Releases are fully automated with
+[semantic-release](https://github.com/semantic-release/semantic-release), which
+derives the next version number from the commits that land on `master`. The type
+decides whether there is a release at all, and which one:
+
+| Type       | Use for                                         | Release   |
+| ---------- | ----------------------------------------------- | --------- |
+| `fix`      | a bug fix in the source                         | **patch** |
+| `feat`     | a feature in the source                         | **minor** |
+| `perf`     | a performance improvement in the source         | **patch** |
+| `revert`   | reverting an earlier commit                     | **patch** |
+| `ci`       | workflows, devcontainer                         | none      |
+| `build`    | build tooling and scripts                       | none      |
+| `docs`     | documentation only                              | none      |
+| `test`     | tests only                                      | none      |
+| `refactor` | internal restructuring with no behaviour change | none      |
+| `style`    | formatting only, no change in behaviour         | none      |
+| `chore`    | anything else                                   | none      |
+
+`fix`, `feat` and `perf` are reserved for changes to the source, because they
+trigger a release. Everything else takes a non-releasing type. A non-releasing
+commit still lands in the history, it just does not cut a version on its own.
 
 ### Breaking changes
 
-Announce a breaking change with a `BREAKING CHANGE:` footer, which triggers a major release:
+A breaking change adds a `BREAKING CHANGE: <summary>` line to the commit body, after
+a blank line. It triggers a major bump **regardless of the type** — a `docs` or
+`chore` commit carrying that footer releases a major just as a `feat` does — so it
+also needs a migration note for consumers in the same change.
 
-```
+```text
 feat(toUnicode): rename the transitional option
 
 BREAKING CHANGE: option `transitional` is now called `transitionalProcessing`.
 ```
 
-The shorthand `feat!:` does **not** work in this repository. The configured Angular preset does not understand the `!` marker, so such a commit is not recognized at all and triggers no release whatsoever, not even the minor one you would get without the `!`. Always use the footer.
+Two things that look like they should work but do not, because the configured
+Angular preset only recognises the literal `BREAKING CHANGE` keyword and does not
+set a breaking-header pattern:
 
-### Examples
+- **`feat(cli)!: …` releases nothing at all.** The `!` makes the header unparseable,
+  so the commit is dropped entirely — you lose even the minor bump you would have
+  got without it. Use the footer.
+- **`BREAKING-CHANGE:` and `BREAKING CHANGES:` are not recognised** either. Only
+  `BREAKING CHANGE` matches, in any capitalisation.
 
-```
-feat(cli): add a command line interface
-fix(toAscii): keep the domain name unchanged when tr46 returns null
-perf(convert): skip the mapping of already converted labels
-docs: describe the pull request process
-chore(deps): refresh node dependencies
-```
+Do **not** add `Co-Authored-By:` trailers.
+
+## Branches and pull requests
+
+Every change goes through a pull request, there are no direct pushes to `master`.
+
+- Branch from an up-to-date default branch: run `git checkout master` and
+  `git pull --ff-only` before `git checkout -b`. Never branch from a stale local
+  `master` or from another feature branch.
+- Name branches after the Jira issue: `RSRMID-1234/short-description`.
+- Keep a pull request focused on one topic. Unrelated changes belong in their own
+  pull request.
+- Include the Jira issue link in the PR description, and add the PR URL as a comment
+  on the Jira issue after opening it.
+- **Rebase-merge** (`gh pr merge --rebase`). Squash merges are disabled at the
+  repository level, because the release tooling reads the individual commits.
+
+Once a pull request is merged, semantic-release publishes the new version to npm,
+tags it, updates `HISTORY.md` and creates the github release. Nothing is released by
+hand.
+
+## Formatting
+
+Prettier owns everything it understands (Markdown, JSON, YAML). `lint-staged` runs
+it over what you staged as part of `pnpm run prepare`, which `pnpm test` triggers,
+so in practice formatting is fixed before it reaches CI. Eslint runs in CI via
+`pnpm run lint`.
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ scope**:
 
 Releases are fully automated with
 [semantic-release](https://github.com/semantic-release/semantic-release), which
-derives the next version number from the commits that land on `master`. The type
+derives the next version number from the commits that land on `main`. The type
 decides whether there is a release at all, and which one:
 
 | Type       | Use for                                         | Release   |
@@ -84,11 +84,11 @@ Do **not** add `Co-Authored-By:` trailers.
 
 ## Branches and pull requests
 
-Every change goes through a pull request, there are no direct pushes to `master`.
+Every change goes through a pull request, there are no direct pushes to `main`.
 
-- Branch from an up-to-date default branch: run `git checkout master` and
+- Branch from an up-to-date default branch: run `git checkout main` and
   `git pull --ff-only` before `git checkout -b`. Never branch from a stale local
-  `master` or from another feature branch.
+  `main` or from another feature branch.
 - Name branches after the Jira issue: `RSRMID-1234/short-description`.
 - Keep a pull request focused on one topic. Unrelated changes belong in their own
   pull request.
@@ -103,10 +103,12 @@ hand.
 
 ## Formatting
 
-Prettier owns everything it understands (Markdown, JSON, YAML). `lint-staged` runs
-it over what you staged as part of `pnpm run prepare`, which `pnpm test` triggers,
-so in practice formatting is fixed before it reaches CI. Eslint runs in CI via
-`pnpm run lint`.
+Prettier owns everything it understands (Markdown, JSON, YAML). The husky pre-commit
+hook runs `lint-staged` over what you staged, so in practice formatting is fixed
+before it reaches CI. `pnpm install` installs the hook, through the `prepare` script.
+The hook is skipped when `CI=true`, so semantic-release's own commits are left alone.
+
+Eslint runs in CI via `pnpm run lint`.
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ## Pull Request Process
 
-Read [here](https://github.com/hexonet/idna-uts46/wiki/Development-Guide#pull-request-pr-procedure).
+Read [here](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/wiki/Development-Guide#pull-request-pr-procedure).
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,79 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ## Pull Request Process
 
-Read [here](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/wiki/Development-Guide#pull-request-pr-procedure).
+Every change goes through a pull request, there are no direct pushes to `master`.
+
+1. Create a branch off `master`, named after what it does, e.g. `feat/cli` or `fix/transitional-detection`.
+2. Keep a pull request focused on one topic. Unrelated changes belong in their own pull request.
+3. Run the checks locally before you push:
+
+   ```bash
+   pnpm install
+   pnpm test    # mocha test suite
+   pnpm lint    # eslint
+   ```
+
+   Formatting is handled by prettier and runs automatically on the staged files via lint-staged.
+
+4. Write your commit messages in the format described below. The release is derived from them, so this is not cosmetic.
+5. Open the pull request against `master` and describe what changed, why, and how you verified it.
+6. Once a maintainer approves and merges, semantic-release publishes the new version to npm, tags it, updates `HISTORY.md` and creates the github release. Nothing is released by hand.
+
+## Commit Messages
+
+Releases are fully automated with [semantic-release](https://github.com/semantic-release/semantic-release), which derives the next version number from the commit messages that land on `master`. We follow the Angular convention:
+
+```
+<type>(<scope>): <short summary>
+
+<optional body>
+
+<optional footer>
+```
+
+- **type** — one of the types listed below, lowercase.
+- **scope** — optional, the part of the package you touched, e.g. `cli`, `deps`, `toAscii`.
+- **short summary** — imperative mood ("add", not "added" or "adds"), no capital first letter, no trailing period.
+
+### Types and their effect on the release
+
+| **Type**   | **Use for**                                          | **Release**           |
+| ---------- | ---------------------------------------------------- | --------------------- |
+| `feat`     | a new feature                                        | minor (1.2.3 → 1.3.0) |
+| `fix`      | a bug fix                                            | patch (1.2.3 → 1.2.4) |
+| `perf`     | a change that improves performance                   | patch                 |
+| `revert`   | reverting an earlier commit                          | patch                 |
+| `docs`     | documentation only                                   | none                  |
+| `refactor` | a change that neither fixes a bug nor adds a feature | none                  |
+| `test`     | adding or correcting tests                           | none                  |
+| `build`    | build system, bundling or dependencies               | none                  |
+| `ci`       | CI configuration and workflows                       | none                  |
+| `style`    | formatting only, no change in behavior               | none                  |
+| `chore`    | maintenance that fits nowhere else                   | none                  |
+
+A type that triggers no release still shows up in the repository history, it just does not produce a new version on its own.
+
+### Breaking changes
+
+Announce a breaking change with a `BREAKING CHANGE:` footer, which triggers a major release:
+
+```
+feat(toUnicode): rename the transitional option
+
+BREAKING CHANGE: option `transitional` is now called `transitionalProcessing`.
+```
+
+The shorthand `feat!:` does **not** work in this repository. The configured Angular preset does not understand the `!` marker, so such a commit is not recognized at all and triggers no release whatsoever, not even the minor one you would get without the `!`. Always use the footer.
+
+### Examples
+
+```
+feat(cli): add a command line interface
+fix(toAscii): keep the domain name unchanged when tr46 returns null
+perf(convert): skip the mapping of already converted labels
+docs: describe the pull request process
+chore(deps): refresh node dependencies
+```
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,9 @@ CI workflows run the same ones, so a green local run is a green build:
 
 ```bash
 pnpm install
-pnpm test    # mocha test suite
-pnpm lint    # eslint
+pnpm test        # mocha test suite
+pnpm lint        # eslint
+pnpm prettier    # formatting check; pnpm prettier:fix rewrites
 ```
 
 ## Commit messages
@@ -107,6 +108,12 @@ Prettier owns everything it understands (Markdown, JSON, YAML). The husky pre-co
 hook runs `lint-staged` over what you staged, so in practice formatting is fixed
 before it reaches CI. `pnpm install` installs the hook, through the `prepare` script.
 The hook is skipped when `CI=true`, so semantic-release's own commits are left alone.
+
+It is gated, not advisory: the Quality workflow runs `pnpm prettier` on every pull
+request, so unformatted Markdown is a red build rather than a local nag everyone
+learns to ignore. Check with `pnpm prettier`, rewrite with `pnpm prettier:fix`. The
+same workflow runs actionlint over the workflow files and shellcheck over the tracked
+shell scripts.
 
 Eslint runs in CI via `pnpm run lint`.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -129,232 +129,232 @@
 
 * **tr46:** Migration to package tr46. Find Notes and Migration Guide as part of the README.md
 
-## [5.1.2](https://github.com/hexonet/idna-uts46/compare/v5.1.1...v5.1.2) (2023-10-31)
+## [5.1.2](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.1.1...v5.1.2) (2023-10-31)
 
 
 ### Bug Fixes
 
-* **deps:** bump punycode from 2.3.0 to 2.3.1 ([1e4d79a](https://github.com/hexonet/idna-uts46/commit/1e4d79ae7b295b0cac5764b2ec0b95105895477e))
+* **deps:** bump punycode from 2.3.0 to 2.3.1 ([1e4d79a](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/1e4d79ae7b295b0cac5764b2ec0b95105895477e))
 
-## [5.1.1](https://github.com/hexonet/idna-uts46/compare/v5.1.0...v5.1.1) (2023-10-20)
+## [5.1.1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.1.0...v5.1.1) (2023-10-20)
 
 
 ### Bug Fixes
 
-* **punycode:** ensure to use the user-land replacement ([6c3a3c2](https://github.com/hexonet/idna-uts46/commit/6c3a3c296624574f663132462ffe6bcf0e406742))
+* **punycode:** ensure to use the user-land replacement ([6c3a3c2](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/6c3a3c296624574f663132462ffe6bcf0e406742))
 
-# [5.1.0](https://github.com/hexonet/idna-uts46/compare/v5.0.7...v5.1.0) (2023-09-18)
+# [5.1.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.0.7...v5.1.0) (2023-09-18)
 
 
 ### Features
 
-* **unicode:** upgraded version ([cb662c3](https://github.com/hexonet/idna-uts46/commit/cb662c306bb2d14416919b91709637fee01f01e8))
+* **unicode:** upgraded version ([cb662c3](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/cb662c306bb2d14416919b91709637fee01f01e8))
 
-## [5.0.7](https://github.com/hexonet/idna-uts46/compare/v5.0.6...v5.0.7) (2023-03-13)
-
-
-### Performance Improvements
-
-* **build:** improve build size again (1kb) ([8b12436](https://github.com/hexonet/idna-uts46/commit/8b12436052c799587c421ef0cfc11fbe420aab51))
-
-## [5.0.6](https://github.com/hexonet/idna-uts46/compare/v5.0.5...v5.0.6) (2023-03-13)
+## [5.0.7](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.0.6...v5.0.7) (2023-03-13)
 
 
 ### Performance Improvements
 
-* **build:** minor improvement to file sizes of dist files ([19e61da](https://github.com/hexonet/idna-uts46/commit/19e61da7cd4e33e402456466de4cfe210dccf25d))
+* **build:** improve build size again (1kb) ([8b12436](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/8b12436052c799587c421ef0cfc11fbe420aab51))
 
-## [5.0.5](https://github.com/hexonet/idna-uts46/compare/v5.0.4...v5.0.5) (2023-03-10)
-
-
-### Bug Fixes
-
-* **esm:** switched to type module while CJS + Bundle can still be directly accessed via dist folder ([c3e1064](https://github.com/hexonet/idna-uts46/commit/c3e10644f6ef64ecd6fea00d609ae6d37f5b2d88))
-
-## [5.0.4](https://github.com/hexonet/idna-uts46/compare/v5.0.3...v5.0.4) (2023-03-09)
+## [5.0.6](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.0.5...v5.0.6) (2023-03-13)
 
 
-### Bug Fixes
+### Performance Improvements
 
-* **package.json:** fix path to main file ([77561b7](https://github.com/hexonet/idna-uts46/commit/77561b70d16fbab75ed40c3e3174b61cb56367cd))
+* **build:** minor improvement to file sizes of dist files ([19e61da](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/19e61da7cd4e33e402456466de4cfe210dccf25d))
 
-## [5.0.3](https://github.com/hexonet/idna-uts46/compare/v5.0.2...v5.0.3) (2023-03-09)
+## [5.0.5](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.0.4...v5.0.5) (2023-03-10)
 
 
 ### Bug Fixes
 
-* **rollup:** merged config files ([05c22d8](https://github.com/hexonet/idna-uts46/commit/05c22d89615fc9d5af58c34cfb71722d30fcc222))
+* **esm:** switched to type module while CJS + Bundle can still be directly accessed via dist folder ([c3e1064](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/c3e10644f6ef64ecd6fea00d609ae6d37f5b2d88))
 
-## [5.0.2](https://github.com/hexonet/idna-uts46/compare/v5.0.1...v5.0.2) (2023-03-09)
-
-
-### Bug Fixes
-
-* **build:** add missing devDependencies ([b3f692a](https://github.com/hexonet/idna-uts46/commit/b3f692a0f7dd5a80dac1b0ed0ab2647862bf03dd))
-* **build:** added missing semantic-release configuration file and typings file ([bd3f43a](https://github.com/hexonet/idna-uts46/commit/bd3f43a8de68d5defe8245a7acf6d539e63799d7))
-* **dist:** some minor review and cleanup of typings ([3fdff33](https://github.com/hexonet/idna-uts46/commit/3fdff33dd360c3ff48f4e91d9f0ced6e25c93409))
-
-## [4.1.2](https://github.com/hexonet/idna-uts46/compare/v4.1.1...v4.1.2) (2022-12-09)
+## [5.0.4](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.0.3...v5.0.4) (2023-03-09)
 
 
 ### Bug Fixes
 
-* **unicode v15.0.0:** regenerated .js files (idna-map files were empty) ([cb00f51](https://github.com/hexonet/idna-uts46/commit/cb00f518d5fd781c82a510abd2ccff585303d137))
+* **package.json:** fix path to main file ([77561b7](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/77561b70d16fbab75ed40c3e3174b61cb56367cd))
 
-## [4.1.1](https://github.com/hexonet/idna-uts46/compare/v4.1.0...v4.1.1) (2022-12-09)
+## [5.0.3](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.0.2...v5.0.3) (2023-03-09)
 
 
 ### Bug Fixes
 
-* **code style:** prettier-ified ([e919514](https://github.com/hexonet/idna-uts46/commit/e919514bd95f349f045290b3c3834a860cb6fe32))
+* **rollup:** merged config files ([05c22d8](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/05c22d89615fc9d5af58c34cfb71722d30fcc222))
 
-# [4.1.0](https://github.com/hexonet/idna-uts46/compare/v4.0.4...v4.1.0) (2022-12-09)
+## [5.0.2](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v5.0.1...v5.0.2) (2023-03-09)
+
+
+### Bug Fixes
+
+* **build:** add missing devDependencies ([b3f692a](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/b3f692a0f7dd5a80dac1b0ed0ab2647862bf03dd))
+* **build:** added missing semantic-release configuration file and typings file ([bd3f43a](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/bd3f43a8de68d5defe8245a7acf6d539e63799d7))
+* **dist:** some minor review and cleanup of typings ([3fdff33](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/3fdff33dd360c3ff48f4e91d9f0ced6e25c93409))
+
+## [4.1.2](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v4.1.1...v4.1.2) (2022-12-09)
+
+
+### Bug Fixes
+
+* **unicode v15.0.0:** regenerated .js files (idna-map files were empty) ([cb00f51](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/cb00f518d5fd781c82a510abd2ccff585303d137))
+
+## [4.1.1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v4.1.0...v4.1.1) (2022-12-09)
+
+
+### Bug Fixes
+
+* **code style:** prettier-ified ([e919514](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/e919514bd95f349f045290b3c3834a860cb6fe32))
+
+# [4.1.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v4.0.4...v4.1.0) (2022-12-09)
 
 
 ### Features
 
-* **unicode v15:** upgrade ([5765785](https://github.com/hexonet/idna-uts46/commit/57657851359e5bbd48fa7ce62e6bfe38a9242834))
+* **unicode v15:** upgrade ([5765785](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/57657851359e5bbd48fa7ce62e6bfe38a9242834))
 
-## [4.0.4](https://github.com/hexonet/idna-uts46/compare/v4.0.3...v4.0.4) (2022-09-14)
+## [4.0.4](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v4.0.3...v4.0.4) (2022-09-14)
 
 
 ### Bug Fixes
 
-* **punycode:** don't use the punycode module shipped with nodejs, read [#148](https://github.com/hexonet/idna-uts46/issues/148) ([78bfc91](https://github.com/hexonet/idna-uts46/commit/78bfc91525de27b633b338d672d9a3a334c6a51b))
+* **punycode:** don't use the punycode module shipped with nodejs, read [#148](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/issues/148) ([78bfc91](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/78bfc91525de27b633b338d672d9a3a334c6a51b))
 
-## [4.0.3](https://github.com/hexonet/idna-uts46/compare/v4.0.2...v4.0.3) (2022-07-04)
+## [4.0.3](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v4.0.2...v4.0.3) (2022-07-04)
 
 
 ### Performance Improvements
 
-* **downsizing idna-map:** moving Uint32Array to const var for reuse and thus downsizing entire file ([da056b9](https://github.com/hexonet/idna-uts46/commit/da056b94736a1b87b55882ea4f9b64655d15122a))
+* **downsizing idna-map:** moving Uint32Array to const var for reuse and thus downsizing entire file ([da056b9](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/da056b94736a1b87b55882ea4f9b64655d15122a))
 
-## [4.0.2](https://github.com/hexonet/idna-uts46/compare/v4.0.1...v4.0.2) (2022-06-08)
-
-
-### Bug Fixes
-
-* **dep bump:** upgraded "engines" and dev deps ([1961f78](https://github.com/hexonet/idna-uts46/commit/1961f78fe9b365940318ad41be24d62759d305e3))
-
-## [4.0.1](https://github.com/hexonet/idna-uts46/compare/v4.0.0...v4.0.1) (2022-06-08)
+## [4.0.2](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v4.0.1...v4.0.2) (2022-06-08)
 
 
 ### Bug Fixes
 
-* **github workflows:** fixed to always rely on latest node version number (nodejs/npm vuln) ([4e01d90](https://github.com/hexonet/idna-uts46/commit/4e01d90cd9f158d4111d8de8fd9257452895ff15))
+* **dep bump:** upgraded "engines" and dev deps ([1961f78](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/1961f78fe9b365940318ad41be24d62759d305e3))
 
-# [4.0.0](https://github.com/hexonet/idna-uts46/compare/v3.5.0...v4.0.0) (2022-05-02)
+## [4.0.1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v4.0.0...v4.0.1) (2022-06-08)
 
 
 ### Bug Fixes
 
-* **dep-bump:** added pkg "future" to requirements.txt until python2 support got totally cleaned up ([6610158](https://github.com/hexonet/idna-uts46/commit/66101588a592983e285616ca131ce948ede08695))
-* **pep8:** fixed addressed issues ([f6e4acc](https://github.com/hexonet/idna-uts46/commit/f6e4accf06ab7e5bc2af71551fd19fe1f01386c4))
+* **github workflows:** fixed to always rely on latest node version number (nodejs/npm vuln) ([4e01d90](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/4e01d90cd9f158d4111d8de8fd9257452895ff15))
+
+# [4.0.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.5.0...v4.0.0) (2022-05-02)
+
+
+### Bug Fixes
+
+* **dep-bump:** added pkg "future" to requirements.txt until python2 support got totally cleaned up ([6610158](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/66101588a592983e285616ca131ce948ede08695))
+* **pep8:** fixed addressed issues ([f6e4acc](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/f6e4accf06ab7e5bc2af71551fd19fe1f01386c4))
 
 
 ### chore
 
-* **python3:** support added for generator script (build-unicode-tables.py) ([ead43c0](https://github.com/hexonet/idna-uts46/commit/ead43c06a4f1ebc6646009084c8962da12718398))
+* **python3:** support added for generator script (build-unicode-tables.py) ([ead43c0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/ead43c06a4f1ebc6646009084c8962da12718398))
 
 
 ### BREAKING CHANGES
 
 * **python3:** Module generated using the python3 ported generator script.
 
-# [3.5.0](https://github.com/hexonet/idna-uts46/compare/v3.4.1...v3.5.0) (2022-05-02)
+# [3.5.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.4.1...v3.5.0) (2022-05-02)
 
 
 ### Features
 
-* **unicode 14.0.0:** upgraded, enjoy! ([4fec362](https://github.com/hexonet/idna-uts46/commit/4fec362a5c637ac95ad7e190538893e88d9064f4))
+* **unicode 14.0.0:** upgraded, enjoy! ([4fec362](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/4fec362a5c637ac95ad7e190538893e88d9064f4))
 
-## [3.4.1](https://github.com/hexonet/idna-uts46/compare/v3.4.0...v3.4.1) (2022-04-29)
+## [3.4.1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.4.0...v3.4.1) (2022-04-29)
 
 
 ### Performance Improvements
 
-* **bundled version:** minify idna-map.js and rely on it as well ([0b0ffc9](https://github.com/hexonet/idna-uts46/commit/0b0ffc97c2393a5e2414839b43bb247e0f1f8269))
+* **bundled version:** minify idna-map.js and rely on it as well ([0b0ffc9](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/0b0ffc97c2393a5e2414839b43bb247e0f1f8269))
 
-# [3.4.0](https://github.com/hexonet/idna-uts46/compare/v3.3.1...v3.4.0) (2021-03-22)
+# [3.4.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.3.1...v3.4.0) (2021-03-22)
 
 
 ### Features
 
-* **unicode:** update to v13.0.0 ([2741d21](https://github.com/hexonet/idna-uts46/commit/2741d214012786ae5ac019abaa733f6a8399f89f))
+* **unicode:** update to v13.0.0 ([2741d21](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/2741d214012786ae5ac019abaa733f6a8399f89f))
 
-## [3.3.1](https://github.com/hexonet/idna-uts46/compare/v3.3.0...v3.3.1) (2021-01-26)
+## [3.3.1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.3.0...v3.3.1) (2021-01-26)
 
 
 ### Bug Fixes
 
-* **ci:** migration from Travis CI to github actions ([ebadb75](https://github.com/hexonet/idna-uts46/commit/ebadb759e0e6de8744daa5c0671fd48676a2f166))
-* **ci:** remove --user flag for pip install ([8749327](https://github.com/hexonet/idna-uts46/commit/874932703364462466f86c5af4ee9692535ecc8a))
+* **ci:** migration from Travis CI to github actions ([ebadb75](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/ebadb759e0e6de8744daa5c0671fd48676a2f166))
+* **ci:** remove --user flag for pip install ([8749327](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/874932703364462466f86c5af4ee9692535ecc8a))
 
 
 ### Reverts
 
-* **travis:** reverting change of travis-ci config ([8e804da](https://github.com/hexonet/idna-uts46/commit/8e804da0b50d63070436d01e9204a1718ee15cf6))
+* **travis:** reverting change of travis-ci config ([8e804da](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/8e804da0b50d63070436d01e9204a1718ee15cf6))
 
-# [3.3.0](https://github.com/hexonet/idna-uts46/compare/v3.2.2...v3.3.0) (2020-05-18)
-
-
-### Features
-
-* **typescript:** adding type definitions ([8d0231f](https://github.com/hexonet/idna-uts46/commit/8d0231f1768da426322c4bab1cf8ae5f12555bf0))
-
-## [3.2.2](https://github.com/hexonet/idna-uts46/compare/v3.2.1...v3.2.2) (2019-09-18)
-
-
-### Bug Fixes
-
-* **release process:** review git-plugin usage; dep-bump cross-env; ([0ec058a](https://github.com/hexonet/idna-uts46/commit/0ec058a))
-
-## [3.2.1](https://github.com/hexonet/idna-uts46/compare/v3.2.0...v3.2.1) (2019-09-18)
-
-
-### Bug Fixes
-
-* **release process:** reuse @hexonet/semantic-release-github-npm-config ([46a3abb](https://github.com/hexonet/idna-uts46/commit/46a3abb))
-
-# [3.2.0](https://github.com/hexonet/idna-uts46/compare/v3.1.1...v3.2.0) (2019-05-16)
+# [3.3.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.2.2...v3.3.0) (2020-05-18)
 
 
 ### Features
 
-* **unicode:** upgrade to v12.1.0 ([ee5877b](https://github.com/hexonet/idna-uts46/commit/ee5877b))
+* **typescript:** adding type definitions ([8d0231f](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/8d0231f1768da426322c4bab1cf8ae5f12555bf0))
 
-## [3.1.1](https://github.com/hexonet/idna-uts46/compare/v3.1.0...v3.1.1) (2019-05-13)
-
-
-### Bug Fixes
-
-* **docs:** fix documentation ([73423d1](https://github.com/hexonet/idna-uts46/commit/73423d1))
-* **docs:** fix documentation ([adcf5a9](https://github.com/hexonet/idna-uts46/commit/adcf5a9))
-
-# [3.1.0](https://github.com/hexonet/idna-uts46/compare/v3.0.0...v3.1.0) (2019-05-13)
+## [3.2.2](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.2.1...v3.2.2) (2019-09-18)
 
 
 ### Bug Fixes
 
-* **dep-add:** missing @semantic-release/exec in dev-deps ([35eb502](https://github.com/hexonet/idna-uts46/commit/35eb502))
+* **release process:** review git-plugin usage; dep-bump cross-env; ([0ec058a](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/0ec058a))
+
+## [3.2.1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.2.0...v3.2.1) (2019-09-18)
+
+
+### Bug Fixes
+
+* **release process:** reuse @hexonet/semantic-release-github-npm-config ([46a3abb](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/46a3abb))
+
+# [3.2.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.1.1...v3.2.0) (2019-05-16)
 
 
 ### Features
 
-* **uts46:** add convert method for automatic conversion of domain names ([84fcbe2](https://github.com/hexonet/idna-uts46/commit/84fcbe2))
+* **unicode:** upgrade to v12.1.0 ([ee5877b](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/ee5877b))
+
+## [3.1.1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.1.0...v3.1.1) (2019-05-13)
+
+
+### Bug Fixes
+
+* **docs:** fix documentation ([73423d1](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/73423d1))
+* **docs:** fix documentation ([adcf5a9](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/adcf5a9))
+
+# [3.1.0](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/compare/v3.0.0...v3.1.0) (2019-05-13)
+
+
+### Bug Fixes
+
+* **dep-add:** missing @semantic-release/exec in dev-deps ([35eb502](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/35eb502))
+
+
+### Features
+
+* **uts46:** add convert method for automatic conversion of domain names ([84fcbe2](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/84fcbe2))
 
 # 3.0.0 (2019-04-15)
 
 ### Documentation
 
-* **readme:** review links ([38e3533](https://github.com/hexonet/idna-uts46/commit/38e3533))
+* **readme:** review links ([38e3533](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/38e3533))
 
 ### Bug Fixes
 
-* **pep8:** fix pep8 format check script ([464ffd4](https://github.com/hexonet/idna-uts46/commit/464ffd4))
-* **travis:** fix build steps ([3f60010](https://github.com/hexonet/idna-uts46/commit/3f60010))
-* **travis:** install python requirements in user space ([bda853a](https://github.com/hexonet/idna-uts46/commit/bda853a))
-* **travis:** review build step requirements and docs ([f890546](https://github.com/hexonet/idna-uts46/commit/f890546))
+* **pep8:** fix pep8 format check script ([464ffd4](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/464ffd4))
+* **travis:** fix build steps ([3f60010](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/3f60010))
+* **travis:** install python requirements in user space ([bda853a](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/bda853a))
+* **travis:** review build step requirements and docs ([f890546](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/f890546))
 
 ### BREAKING CHANGES
 
@@ -362,7 +362,7 @@
 
 ### Features
 
-* **pkg:** upgrade to unicode 12.0.0; introduce travis ci ([ecfc57f](https://github.com/hexonet/idna-uts46/commit/ecfc57f))
+* **pkg:** upgrade to unicode 12.0.0; introduce travis ci ([ecfc57f](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/commit/ecfc57f))
 
 ### OLDER RELEASES (manually documented)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![node](https://img.shields.io/node/v/idna-uts46-hx.svg)](https://www.npmjs.com/package/idna-uts46-hx)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/blob/master/CONTRIBUTING.md)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/blob/main/CONTRIBUTING.md)
 
 This module is a IDNA UTS46 connector library for javascript. In addition to the default functionality of tr46, we offer converting domain names to unicode / punycode considering the respective registry provider's behavior.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,71 @@ the full mapping for these strings, as defined by
 - [Documentation](https://support.centralnicreseller.com/hc/en-gb/articles/13509920188061-JavaScript-based-IDN-Converter)
 - [Release Notes](https://github.com/hexonet/idna-uts46/releases)
 
+## Command Line Interface
+
+The package ships the `idna-uts46-hx` executable. Use it without installing:
+
+```bash
+npx idna-uts46-hx öbb.at
+# öbb.at	xn--bb-eka.at
+```
+
+By default every input domain name is printed as `<unicode>` and `<punycode>`,
+separated by a tab. Restrict the output to one of both representations with
+`--to`:
+
+```bash
+idna-uts46-hx --to ascii faß.de
+# xn--fa-hia.de
+
+idna-uts46-hx --to unicode xn----5da7e.de
+# ä-ü.de
+```
+
+Domain names can be passed as arguments or piped in via stdin, one per line,
+which makes bulk conversion straightforward:
+
+```bash
+cat domains.txt | idna-uts46-hx --to ascii > punycode.txt
+```
+
+Use `--json` for machine-readable output, including per-domain error messages:
+
+```bash
+idna-uts46-hx --json öbb.at
+# [
+#   {
+#     "input": "öbb.at",
+#     "IDN": "öbb.at",
+#     "PC": "xn--bb-eka.at"
+#   }
+# ]
+```
+
+### Options
+
+| **Option**            | **Description**                                 |
+| --------------------- | ----------------------------------------------- |
+| `-t`, `--to <mode>`   | `ascii`, `unicode` or `both` (default: `both`)  |
+| `-j`, `--json`        | emit JSON instead of plain text                 |
+| `-s`, `--separator`   | column separator for mode `both` (default: tab) |
+| `--transitional`      | force `transitionalProcessing` on               |
+| `--no-transitional`   | force `transitionalProcessing` off              |
+| `--std3`              | apply `useSTD3ASCIIRules`                       |
+| `--verify-dns-length` | apply `verifyDNSLength`                         |
+| `--check-hyphens`     | apply `checkHyphens`                            |
+| `--check-bidi`        | apply `checkBidi`                               |
+| `--check-joiners`     | apply `checkJoiners`                            |
+| `-h`, `--help`        | show the help                                   |
+| `-v`, `--version`     | show the version                                |
+
+Without `--transitional` / `--no-transitional`, transitional processing is
+auto-detected from the TLD, just like in the library API.
+
+The exit code is `0` when all conversions succeeded, `1` when at least one
+domain name could not be converted (the reason is written to stderr, the
+remaining domain names are still processed) and `2` on invalid usage.
+
 ## v6 Notes & Migration Guide
 
 With v6 we migrated our library to npm package `tr46` as software dependency. By that step we use a library that is actively maintained in direction of correctly supporting the `TR46` standard and supporting the latest Version of the Unicode Standard. Reinventing the wheel isn't useful and something we have time or resources for. We were able to dramatically decrease the number of lines of code on our end.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![node](https://img.shields.io/node/v/idna-uts46-hx.svg)](https://www.npmjs.com/package/idna-uts46-hx)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/hexonet/idna-uts46/blob/master/CONTRIBUTING.md)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/blob/master/CONTRIBUTING.md)
 
 This module is a IDNA UTS46 connector library for javascript. In addition to the default functionality of tr46, we offer converting domain names to unicode / punycode considering the respective registry provider's behavior.
 
@@ -19,7 +19,7 @@ the full mapping for these strings, as defined by
 ## Resources
 
 - [Documentation](https://support.centralnicreseller.com/hc/en-gb/articles/13509920188061-JavaScript-based-IDN-Converter)
-- [Release Notes](https://github.com/hexonet/idna-uts46/releases)
+- [Release Notes](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/releases)
 
 ## Command Line Interface
 
@@ -130,7 +130,7 @@ The `toUnicode` function did not allow for a options parameter in earlier versio
 - v5: Migration of the IDNA Mapping Table's Build Process from Python to NodeJS5 by [dawsbot](https://github.com/dawsbot)
 - v5: Performance Improvements for the Browser Bundle's Page Load by [dawsbot](https://github.com/dawsbot)
 
-See also the list of [contributors](https://github.com/hexonet/idna-uts46/graphs/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/graphs/contributors) who participated in this project.
 
 ## License
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -14,7 +14,7 @@ module.exports = [
   {
     ...recommended,
     languageOptions: {
-      ecmaVersion: 2019,
+      ecmaVersion: 2022,
       sourceType: 'module',
       globals: {
         ...globals.es6,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "cli"
   ],
   "scripts": {
-    "prettier": "prettier -u --write \"**/*\"",
+    "prettier": "prettier --check .",
+    "prettier:fix": "prettier --write .",
     "build": "rollup -c rollup-esm.config.mjs",
     "pretest": "pnpm run prepare",
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "preserve": "pnpm run prepare; cp node_modules/mocha/mocha.css dist/index.bundle.js dist/index.mjs test",
     "serve": "vite",
     "lint": "eslint .",
-    "prepare": "pnpm run build && pnpm exec lint-staged"
+    "prepare": "husky && pnpm run build"
   },
   "dependencies": {
     "tr46": "^6.0.0"
@@ -65,6 +65,7 @@
     "c8": "^12.0.0",
     "eslint": "^10.9.1",
     "globals": "^17.12.0",
+    "husky": "^9.1.7",
     "lint-staged": "^17.4.1",
     "mocha": "^11.8.0",
     "prettier": "^3.9.6",
@@ -76,7 +77,9 @@
     "vite": "^8.2.2"
   },
   "lint-staged": {
-    "*": "prettier -u --write"
+    "**/*": [
+      "prettier --write --ignore-unknown"
+    ]
   },
   "prettier": {
     "trailingComma": "all",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "main": "dist/index.mjs",
   "typings": "dist/index.d.ts",
+  "bin": {
+    "idna-uts46-hx": "src/cli.js"
+  },
   "files": [
     "dist/",
     "src/"
@@ -32,7 +35,8 @@
     "idna",
     "domain",
     "convert",
-    "converter"
+    "converter",
+    "cli"
   ],
   "scripts": {
     "prettier": "prettier -u --write \"**/*\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,6 @@
 lockfileVersion: '9.0'
 
 importers:
-
   .:
     configDependencies: {}
     packageManagerDependencies:
@@ -14,115 +13,170 @@ importers:
         version: 11.25.0
 
 packages:
-
   '@pnpm/exe@11.25.0':
-    resolution: {integrity: sha512-X19R2uC+VAJ4UJQE9c/PCdOXbDaWnZtad7WUrTHBFQuMVaK9MAHbyO/WgahQCuRtTmJkLbxcWKKCk+JeTYFm/g==}
+    resolution:
+      {
+        integrity: sha512-X19R2uC+VAJ4UJQE9c/PCdOXbDaWnZtad7WUrTHBFQuMVaK9MAHbyO/WgahQCuRtTmJkLbxcWKKCk+JeTYFm/g==,
+      }
     hasBin: true
 
   '@pnpm/linux-arm64@11.25.0':
-    resolution: {integrity: sha512-ra8akqhzsbcOhKSJ9fFV8H+Oc9uGQAcp/XmIBEdT+8hPPoZCit3+RNCHmg8bLoNvpSLtRvZE0WFCMj7WyzxeBA==}
+    resolution:
+      {
+        integrity: sha512-ra8akqhzsbcOhKSJ9fFV8H+Oc9uGQAcp/XmIBEdT+8hPPoZCit3+RNCHmg8bLoNvpSLtRvZE0WFCMj7WyzxeBA==,
+      }
     cpu: [arm64]
     os: [linux]
 
   '@pnpm/linux-x64@11.25.0':
-    resolution: {integrity: sha512-pQl/L10diKQCbF73viRrtVU8qVWMTudUCSG1uZ+EWBNKtU9Sbxe6Q378diXDb1uTwSgUVMQoypxlC1MTzh7qvQ==}
+    resolution:
+      {
+        integrity: sha512-pQl/L10diKQCbF73viRrtVU8qVWMTudUCSG1uZ+EWBNKtU9Sbxe6Q378diXDb1uTwSgUVMQoypxlC1MTzh7qvQ==,
+      }
     cpu: [x64]
     os: [linux]
 
   '@pnpm/linuxstatic-arm64@11.25.0':
-    resolution: {integrity: sha512-cYcrbB/xN1N6/5VUlFuHblb1gNyJgZv1CF5Pk1T0sHJxQMY4DFJV3OqHVAgahxyUfSTaQcVLvH1H2JFvd/+sgw==}
+    resolution:
+      {
+        integrity: sha512-cYcrbB/xN1N6/5VUlFuHblb1gNyJgZv1CF5Pk1T0sHJxQMY4DFJV3OqHVAgahxyUfSTaQcVLvH1H2JFvd/+sgw==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@pnpm/linuxstatic-x64@11.25.0':
-    resolution: {integrity: sha512-HXDtaeQod16DDMUUcVLIMxvEc1jKn7IYsNPwbwAPs/Je/d3umRPJi3Ejjdn6e9qpXN6Oon+yvSsJr7B9oDt6KA==}
+    resolution:
+      {
+        integrity: sha512-HXDtaeQod16DDMUUcVLIMxvEc1jKn7IYsNPwbwAPs/Je/d3umRPJi3Ejjdn6e9qpXN6Oon+yvSsJr7B9oDt6KA==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@pnpm/macos-arm64@11.25.0':
-    resolution: {integrity: sha512-m/eAgEqKhiSexGxWPHNXNnSRI0hudymg6K7LbrU2EoDs9IgJ28OKEz9mGxMzhkYBweEquR4k5teMNes/aToy9w==}
+    resolution:
+      {
+        integrity: sha512-m/eAgEqKhiSexGxWPHNXNnSRI0hudymg6K7LbrU2EoDs9IgJ28OKEz9mGxMzhkYBweEquR4k5teMNes/aToy9w==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   '@pnpm/win-arm64@11.25.0':
-    resolution: {integrity: sha512-oAeECbtZ+eJziaBmPUkwJM8Dx7KVQ5FO367AXTjD2HGfB5ob1Bcu5hoUF5RBTgDBiP9fRQ1u13uAEpqar/6NLA==}
+    resolution:
+      {
+        integrity: sha512-oAeECbtZ+eJziaBmPUkwJM8Dx7KVQ5FO367AXTjD2HGfB5ob1Bcu5hoUF5RBTgDBiP9fRQ1u13uAEpqar/6NLA==,
+      }
     cpu: [arm64]
     os: [win32]
 
   '@pnpm/win-x64@11.25.0':
-    resolution: {integrity: sha512-8/n+wCc0a8TRYTMFqti93Vh0cscdJ25xfMyYSDdXrLUh2ccxSFuS+SE7cNPjd/nOXoFAJvdW0kwfbyRPLa16/w==}
+    resolution:
+      {
+        integrity: sha512-8/n+wCc0a8TRYTMFqti93Vh0cscdJ25xfMyYSDdXrLUh2ccxSFuS+SE7cNPjd/nOXoFAJvdW0kwfbyRPLa16/w==,
+      }
     cpu: [x64]
     os: [win32]
 
   '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==,
+      }
+    engines: { node: '>= 10' }
     cpu: [arm64]
     os: [darwin]
 
   '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==,
+      }
+    engines: { node: '>= 10' }
     cpu: [x64]
     os: [darwin]
 
   '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==,
+      }
+    engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==,
+      }
+    engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==,
+      }
+    engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==,
+      }
+    engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==,
+      }
+    engines: { node: '>= 10' }
     cpu: [arm64]
     os: [win32]
 
   '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==,
+      }
+    engines: { node: '>= 10' }
     cpu: [x64]
     os: [win32]
 
   '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==,
+      }
+    engines: { node: '>= 10' }
 
   detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: '>=8' }
 
   pnpm@11.25.0:
-    resolution: {integrity: sha512-XN6SW08HX3Jetx+64YpC/+eEUkeJ8ZthxzHLhyHsKKruFg4BqNWvT+2ypCzb8wDv4j2zVrDUoXtNY+EfirfJVg==}
-    engines: {node: '>=22.13'}
+    resolution:
+      {
+        integrity: sha512-XN6SW08HX3Jetx+64YpC/+eEUkeJ8ZthxzHLhyHsKKruFg4BqNWvT+2ypCzb8wDv4j2zVrDUoXtNY+EfirfJVg==,
+      }
+    engines: { node: '>=22.13' }
     hasBin: true
 
 snapshots:
-
   '@pnpm/exe@11.25.0':
     dependencies:
       '@reflink/reflink': 0.1.19
@@ -251,6 +305,9 @@ importers:
       globals:
         specifier: ^17.12.0
         version: 17.12.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       lint-staged:
         specifier: ^17.4.1
         version: 17.4.1
@@ -972,8 +1029,8 @@ packages:
       bare-buffer:
         optional: true
 
-  bare-path@3.1.2:
-    resolution: {integrity: sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==}
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
 
   bare-stream@2.13.4:
     resolution: {integrity: sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==}
@@ -989,8 +1046,8 @@ packages:
       bare-events:
         optional: true
 
-  bare-url@2.5.3:
-    resolution: {integrity: sha512-3absfEzoyFosWT8v83ZcJgbTJxv+S/sI7jBfeCMlUVatSaefRmwweqBhFpMllQv+HTxs/FbbToVOw1c05NORkQ==}
+  bare-url@2.5.2:
+    resolution: {integrity: sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1546,6 +1603,11 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3330,15 +3392,15 @@ snapshots:
   bare-fs@4.8.1:
     dependencies:
       bare-events: 2.9.2
-      bare-path: 3.1.2
+      bare-path: 3.1.1
       bare-stream: 2.13.4(bare-events@2.9.2)
-      bare-url: 2.5.3
+      bare-url: 2.5.2
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
 
-  bare-path@3.1.2: {}
+  bare-path@3.1.1: {}
 
   bare-stream@2.13.4(bare-events@2.9.2):
     dependencies:
@@ -3350,9 +3412,9 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
-  bare-url@2.5.3:
+  bare-url@2.5.2:
     dependencies:
-      bare-path: 3.1.2
+      bare-path: 3.1.1
 
   base64-js@1.5.1: {}
 
@@ -3922,6 +3984,8 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
+
+  husky@9.1.7: {}
 
   ieee754@1.2.1: {}
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+'use strict';
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import { toAscii, toUnicode } from './index.js';
+
+const pkg = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+);
+
+const USAGE = `Usage: idna-uts46-hx [options] [domain ...]
+
+Convert domain names between Unicode (IDN) and Punycode (ASCII) using
+UTS #46 processing. Domains may also be piped in via stdin, one per line.
+
+Options:
+  -t, --to <mode>          ascii | unicode | both   (default: both)
+  -j, --json               emit JSON instead of plain text
+  -s, --separator <sep>    column separator for mode "both" (default: tab)
+      --transitional       force transitional processing on
+      --no-transitional    force transitional processing off
+                           (default: auto-detected from the TLD)
+      --std3               apply useSTD3ASCIIRules
+      --verify-dns-length  apply verifyDNSLength
+      --check-hyphens      apply checkHyphens
+      --check-bidi         apply checkBidi
+      --check-joiners      apply checkJoiners
+  -h, --help               show this help
+  -v, --version            show the version
+
+Exit codes: 0 = all conversions succeeded, 1 = at least one failed,
+2 = invalid usage.
+
+Examples:
+  idna-uts46-hx öbb.at
+  idna-uts46-hx --to ascii faß.de
+  idna-uts46-hx --to unicode xn----5da7e.de
+  cat domains.txt | idna-uts46-hx --json
+`;
+
+const OPTIONS = {
+  to: { type: 'string', short: 't', default: 'both' },
+  json: { type: 'boolean', short: 'j', default: false },
+  separator: { type: 'string', short: 's', default: '\t' },
+  transitional: { type: 'boolean', default: false },
+  'no-transitional': { type: 'boolean', default: false },
+  std3: { type: 'boolean', default: false },
+  'verify-dns-length': { type: 'boolean', default: false },
+  'check-hyphens': { type: 'boolean', default: false },
+  'check-bidi': { type: 'boolean', default: false },
+  'check-joiners': { type: 'boolean', default: false },
+  help: { type: 'boolean', short: 'h', default: false },
+  version: { type: 'boolean', short: 'v', default: false },
+};
+
+class UsageError extends Error {}
+
+function toTr46Options(values) {
+  const options = {};
+  if (values.transitional && values['no-transitional']) {
+    throw new UsageError(
+      'Options --transitional and --no-transitional are mutually exclusive.',
+    );
+  }
+  if (values.transitional) {
+    options.transitionalProcessing = true;
+  }
+  if (values['no-transitional']) {
+    options.transitionalProcessing = false;
+  }
+  if (values.std3) {
+    options.useSTD3ASCIIRules = true;
+  }
+  if (values['verify-dns-length']) {
+    options.verifyDNSLength = true;
+  }
+  if (values['check-hyphens']) {
+    options.checkHyphens = true;
+  }
+  if (values['check-bidi']) {
+    options.checkBidi = true;
+  }
+  if (values['check-joiners']) {
+    options.checkJoiners = true;
+  }
+  return options;
+}
+
+function convertOne(domainName, mode, options) {
+  if (mode === 'ascii') {
+    return { input: domainName, PC: toAscii(domainName, options) };
+  }
+  if (mode === 'unicode') {
+    return { input: domainName, IDN: toUnicode(domainName, options) };
+  }
+  const idn = toUnicode(domainName, options);
+  return { input: domainName, IDN: idn, PC: toAscii(idn, options) };
+}
+
+function formatText(result, mode, separator) {
+  if (mode === 'ascii') {
+    return result.PC;
+  }
+  if (mode === 'unicode') {
+    return result.IDN;
+  }
+  return `${result.IDN}${separator}${result.PC}`;
+}
+
+function readStdin(stream) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => {
+      data += chunk;
+    });
+    stream.on('end', () => resolve(data));
+    stream.on('error', reject);
+  });
+}
+
+async function collectDomainNames(positionals, stdin) {
+  if (positionals.length > 0) {
+    return positionals;
+  }
+  if (stdin.isTTY) {
+    throw new UsageError('No domain names given.');
+  }
+  return (await readStdin(stdin))
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+async function run(argv, io) {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: OPTIONS,
+      allowPositionals: true,
+    });
+  } catch (error) {
+    throw new UsageError(error.message);
+  }
+  const { values, positionals } = parsed;
+
+  if (values.help) {
+    io.stdout.write(USAGE);
+    return 0;
+  }
+  if (values.version) {
+    io.stdout.write(`${pkg.version}\n`);
+    return 0;
+  }
+
+  const mode = values.to.toLowerCase();
+  if (!['ascii', 'unicode', 'both'].includes(mode)) {
+    throw new UsageError(
+      `Unknown mode "${values.to}", expected one of: ascii, unicode, both.`,
+    );
+  }
+
+  const options = toTr46Options(values);
+  const domainNames = await collectDomainNames(positionals, io.stdin);
+
+  const results = [];
+  let failed = false;
+  domainNames.forEach((domainName) => {
+    try {
+      results.push(convertOne(domainName, mode, options));
+    } catch (error) {
+      failed = true;
+      results.push({ input: domainName, error: error.message });
+    }
+  });
+
+  if (values.json) {
+    io.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+  } else {
+    results.forEach((result) => {
+      if (result.error) {
+        io.stderr.write(`${result.error}\n`);
+      } else {
+        io.stdout.write(`${formatText(result, mode, values.separator)}\n`);
+      }
+    });
+  }
+
+  return failed ? 1 : 0;
+}
+
+async function main(argv, io) {
+  try {
+    return await run(argv, io);
+  } catch (error) {
+    if (error instanceof UsageError) {
+      io.stderr.write(`${error.message}\n\n${USAGE}`);
+      return 2;
+    }
+    throw error;
+  }
+}
+
+/* c8 ignore start */
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main(process.argv.slice(2), {
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  }).then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+/* c8 ignore stop */
+
+export { main };

--- a/test/test-cli.spec.js
+++ b/test/test-cli.spec.js
@@ -1,0 +1,161 @@
+'use strict';
+
+import assert from 'assert';
+import { spawnSync } from 'node:child_process';
+import { Readable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { main } from '../src/cli.js';
+
+const CLI = fileURLToPath(new URL('../src/cli.js', import.meta.url));
+
+function collector() {
+  const chunks = [];
+  return {
+    write(chunk) {
+      chunks.push(chunk);
+      return true;
+    },
+    get text() {
+      return chunks.join('');
+    },
+  };
+}
+
+async function cli(args, stdin = null) {
+  const stdout = collector();
+  const stderr = collector();
+  const code = await main(args, {
+    stdin: stdin === null ? { isTTY: true } : Readable.from([stdin]),
+    stdout,
+    stderr,
+  });
+  return { code, stdout: stdout.text, stderr: stderr.text };
+}
+
+suite('cli', function () {
+  test('converts to both representations by default', async function () {
+    const result = await cli(['öbb.at', 'xn----5da7e.de']);
+    assert.strict.equal(result.code, 0);
+    assert.strict.equal(
+      result.stdout,
+      'öbb.at\txn--bb-eka.at\nä-ü.de\txn----zfa7e.de\n',
+    );
+    assert.strict.equal(result.stderr, '');
+  });
+
+  test('honors the custom separator', async function () {
+    const result = await cli(['--separator', ' => ', 'öbb.at']);
+    assert.strict.equal(result.stdout, 'öbb.at => xn--bb-eka.at\n');
+  });
+
+  test('converts to ascii only', async function () {
+    const result = await cli(['--to', 'ascii', 'öbb.at']);
+    assert.strict.equal(result.code, 0);
+    assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+  });
+
+  test('converts to unicode only', async function () {
+    const result = await cli(['-t', 'UNICODE', 'xn--bb-eka.at']);
+    assert.strict.equal(result.code, 0);
+    assert.strict.equal(result.stdout, 'öbb.at\n');
+  });
+
+  test('applies transitional processing switches', async function () {
+    assert.strict.equal(
+      (await cli(['-t', 'ascii', '--transitional', 'faß.de'])).stdout,
+      'fass.de\n',
+    );
+    assert.strict.equal(
+      (await cli(['-t', 'ascii', '--no-transitional', 'faß.de'])).stdout,
+      'xn--fa-hia.de\n',
+    );
+  });
+
+  test('passes tr46 flags through', async function () {
+    const result = await cli([
+      '-t',
+      'ascii',
+      '--std3',
+      '--verify-dns-length',
+      '--check-hyphens',
+      '--check-bidi',
+      '--check-joiners',
+      'öbb.at',
+    ]);
+    assert.strict.equal(result.code, 0);
+    assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+  });
+
+  test('reads domain names from stdin', async function () {
+    const result = await cli(['-t', 'ascii'], 'öbb.at\n\n  faß.de  \r\n');
+    assert.strict.equal(result.code, 0);
+    assert.strict.equal(result.stdout, 'xn--bb-eka.at\nxn--fa-hia.de\n');
+  });
+
+  test('emits json', async function () {
+    const result = await cli(['--json', 'öbb.at']);
+    assert.strict.deepEqual(JSON.parse(result.stdout), [
+      { input: 'öbb.at', IDN: 'öbb.at', PC: 'xn--bb-eka.at' },
+    ]);
+  });
+
+  test('reports conversion failures and exits with 1', async function () {
+    const invalid = String.fromCodePoint(0xd0000);
+    const result = await cli([invalid, 'öbb.at']);
+    assert.strict.equal(result.code, 1);
+    assert.strict.equal(result.stdout, 'öbb.at\txn--bb-eka.at\n');
+    assert.strict.match(result.stderr, /Unable to translate/);
+  });
+
+  test('reports conversion failures in json mode', async function () {
+    const invalid = String.fromCodePoint(0xd0000);
+    const result = await cli(['--json', invalid]);
+    assert.strict.equal(result.code, 1);
+    const parsed = JSON.parse(result.stdout);
+    assert.strict.equal(parsed[0].input, invalid);
+    assert.strict.match(parsed[0].error, /Unable to translate/);
+  });
+
+  test('rejects an unknown mode', async function () {
+    const result = await cli(['--to', 'klingon', 'öbb.at']);
+    assert.strict.equal(result.code, 2);
+    assert.strict.equal(result.stdout, '');
+    assert.strict.match(result.stderr, /Unknown mode "klingon"/);
+  });
+
+  test('rejects an unknown option', async function () {
+    const result = await cli(['--nope']);
+    assert.strict.equal(result.code, 2);
+    assert.strict.match(result.stderr, /Usage:/);
+  });
+
+  test('rejects contradicting transitional switches', async function () {
+    const result = await cli(['--transitional', '--no-transitional', 'öbb.at']);
+    assert.strict.equal(result.code, 2);
+    assert.strict.match(result.stderr, /mutually exclusive/);
+  });
+
+  test('rejects a missing domain name on a tty', async function () {
+    const result = await cli([]);
+    assert.strict.equal(result.code, 2);
+    assert.strict.match(result.stderr, /No domain names given/);
+  });
+
+  test('prints help and version', async function () {
+    const help = await cli(['--help']);
+    assert.strict.equal(help.code, 0);
+    assert.strict.match(help.stdout, /^Usage: idna-uts46-hx/);
+
+    const version = await cli(['--version']);
+    assert.strict.equal(version.code, 0);
+    assert.strict.match(version.stdout, /^\d+\.\d+\.\d+/);
+  });
+
+  test('runs as an executable script', function () {
+    const result = spawnSync(process.execPath, [CLI, '-t', 'ascii', 'öbb.at'], {
+      encoding: 'utf8',
+    });
+    assert.strict.equal(result.status, 0);
+    assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+  });
+});


### PR DESCRIPTION
Jira: [RSRMID-3039](https://centralnic.atlassian.net/browse/RSRMID-3039) (CLI), [RSRMID-3040](https://centralnic.atlassian.net/browse/RSRMID-3040) (namespace migration)

Six commits, each standalone.

## `feat(cli)`: command line interface

Ships the `idna-uts46-hx` executable so domain names can be converted from the shell:

```bash
npx idna-uts46-hx öbb.at
# öbb.at	xn--bb-eka.at

idna-uts46-hx --to ascii faß.de
# xn--fa-hia.de

cat domains.txt | idna-uts46-hx --to ascii --json
```

- `-t, --to ascii|unicode|both`, `-j, --json`, `-s, --separator`, `--transitional` / `--no-transitional`, plus pass-through flags for `--std3`, `--verify-dns-length`, `--check-hyphens`, `--check-bidi` and `--check-joiners`.
- Transitional processing stays auto-detected from the TLD unless forced, same as the library API.
- Exit codes: `0` all converted, `1` at least one failed (reason on stderr, remaining names still processed), `2` invalid usage.
- Argument parsing via node's built-in `parseArgs`, so no new dependency.
- `bin` points at `src/cli.js` rather than a rollup output: `src/` ships already and bundling would duplicate the `tr46` unicode mapping table into `dist/`. Confirmed present via `npm pack --dry-run`.
- `main(argv, io)` takes its streams as a parameter, keeping it testable in process. 16 new tests cover all three modes, stdin input, JSON output, every option and every error path, plus one real `spawnSync` run.
- The eslint `ecmaVersion` bump (2019 → 2022) is required to parse the `import.meta` that reads the version out of package.json.

## `docs`: github namespace migration

`github.com/hexonet` became `github.com/centralnicgroup-opensource`, repo renamed to `rtldev-middleware-idna-uts46`. Old URLs only resolved via github's rename redirects, so they now point at the current location: README badge, release notes and contributors links, and the 66 generated changelog links in HISTORY.md.

Left as-is on purpose: the fork attribution in LICENSE (it records where the fork lived 2017–2023) and the `@hexonet/semantic-release-github-npm-config` package name quoted in a 2019 commit message.

## `docs`: contribution guide

The pull request process was a link into a wiki we no longer maintain. Replaced with the org standard — the structure of [rtldev-middleware-template](https://github.com/centralnicgroup-opensource/rtldev-middleware-template)'s CONTRIBUTING.md, adapted where this repo differs (default branch, no CLAUDE.md, no commitizen, and a `prepare` that must keep building).

The release table extends the template's with `perf`, `revert` and `style`; `perf` and `revert` do cut a patch release under the analyzer's default rules, so omitting them would imply they are release-neutral.

Two pitfalls are documented, both verified against the installed toolchain rather than assumed:

- **`feat(cli)!:` releases nothing at all.** `conventional-changelog-angular` 8.3.1 matches headers with `/^(\w*)(?:\((.*)\))?: (.*)$/` and sets no `breakingHeaderPattern`, so the `!` makes the header unparseable and the commit is dropped whole — not even the minor bump survives.
- **`BREAKING-CHANGE:` and `BREAKING CHANGES:` are not recognised.** The preset registers only the literal `BREAKING CHANGE` note keyword (matched case-insensitively).

A `BREAKING CHANGE:` footer triggers major **regardless of type** — verified that `docs`, `chore` and `refactor` commits carrying it all release a major.

## `build(husky)`: lint-staged from a pre-commit hook

Mirrors the husky setup of the template and php-sdk repos: husky devDependency, `.husky/pre-commit` running `pnpm exec lint-staged`, same `[ "$CI" = "true" ] && exit 0` guard so semantic-release's own commits aren't reformatted mid-release. lint-staged glob aligned to the org pattern (`**/*` with `prettier --write --ignore-unknown`).

Previously lint-staged ran from `prepare`, i.e. on install and on every build instead of on a commit.

Deviation from both reference repos, which set `prepare` to plain `husky`: here it is `husky && pnpm run build`. `prepare` is what produces `dist/`, and both `@semantic-release/exec` (`prepareCmd`) and the npm publish lifecycle depend on it, so dropping the build would publish an empty package.

Note the node-sdk repo has **no** husky — it enforces prettier inside its `lint` script instead. The template and php-sdk were used as the reference.

## `ci(main)`: default branch master → main

The branch is renamed on github (done — default branch is now `main`, this PR retargeted itself, old URLs redirect). This commit points the in-repo references at it: the release workflow's push trigger, the dependency-refresh `base-ref`, the CONTRIBUTING wording and the README link into CONTRIBUTING.md.

`.releaserc.json` needs no change — semantic-release's default `branches` list carries both `master` and `main`.

## `ci(quality)`: prettier scripts aligned and formatting gated in CI

`prettier` now checks (`prettier --check .`) and `prettier:fix` rewrites, matching the template and php-sdk. It used to *write* here, so `pnpm prettier` silently reformatted the tree instead of reporting on it.

Adds the template's language-agnostic Quality workflow: prettier over everything it understands, actionlint over the workflow files, shellcheck over the tracked shell scripts, behind a single completion gate. Until now only eslint ran in CI, leaving Markdown, JSON and YAML formatting unenforced.

`.prettierignore` rebuilt on the same lines — it stops excluding `.github` (the point of the exercise) and starts excluding `pnpm-lock.yaml`, `.pnpm-store` and the generated copies under `test/`, none of which were listed. `HISTORY.md` stays excluded, with the template's reasoning recorded: semantic-release commits it without passing it through lint-staged, so any human edit would reflow the whole changelog.

Deviation from the template, deliberate: the workflow pins checkout@v7, setup-node@v7 and pnpm/action-setup@v6.0.10 to match the shared workflows this repo already calls, rather than the older versions the template carries.

The `.github` reformat is double to single quotes only, from this repo's `singleQuote: true`. The prettier *config* itself still differs from the org standard (`singleQuote: false`, `trailingComma: "es5"`); aligning it would rewrite every string literal in the sources, so it is left for its own change.

## Test plan

- `pnpm install --frozen-lockfile` — clean. Worth noting: this branch was rebased onto `main` after `a853f0f` bumped `globals` and `@team-internet/semantic-release-plugins`. Github reported the pre-rebase branch as MERGEABLE/CLEAN, but the merged result would have had package.json and pnpm-lock.yaml disagreeing and failed this exact step in CI. The lockfile was regenerated, both bumps preserved.
- `pnpm test` — 24 passing (8 pre-existing, 16 new).
- `pnpm lint` — clean.
- `prettier --check` — clean.
- Pre-commit hook exercised on two real commits in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-3039]: https://centralnic.atlassian.net/browse/RSRMID-3039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSRMID-3040]: https://centralnic.atlassian.net/browse/RSRMID-3040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ