### PR TITLE
build(devcontainer): commit the feature lockfile

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,29 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/centralnicgroup-opensource/rtldev-middleware-devcontainer-features/devbase:1": {
+      "version": "1.7.0",
+      "resolved": "ghcr.io/centralnicgroup-opensource/rtldev-middleware-devcontainer-features/devbase@sha256:ad01dc166b9e15c08099ca2bbceb59ebdaf2a83eebf08e5ab0a1a1e656ffc35a",
+      "integrity": "sha256:ad01dc166b9e15c08099ca2bbceb59ebdaf2a83eebf08e5ab0a1a1e656ffc35a",
+      "dependsOn": [
+        "ghcr.io/devcontainers/features/node:2",
+        "ghcr.io/anthropics/devcontainer-features/claude-code:1",
+        "ghcr.io/devcontainers/features/github-cli:1"
+      ]
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.2",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805",
+      "integrity": "sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
+    }
+  }
+}


### PR DESCRIPTION
`.devcontainer/devcontainer-lock.json` was generated when the devcontainer was first built but never committed — it has been sitting untracked in the working tree.

Tracking it pins the resolved feature digests, so every rebuild and every contributor gets the same layers instead of whatever the tags point at on the day:

| Feature | Version |
| --- | --- |
| `rtldev-middleware-devcontainer-features/devbase` | 1.7.0 |
| `devcontainers/features/node` | 2.1.0 |
| `devcontainers/features/github-cli` | 1.1.2 |
| `anthropics/devcontainer-features/claude-code` | 1.0.5 |

No source, build or release impact — `build` type, so semantic-release cuts nothing.

## Test plan

Content-only change to a previously untracked generated file; verified it is not gitignored and matches the features declared in `devcontainer.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)