### PR TITLE
fix(cli): run when invoked through the npm bin symlink

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,6 @@
 'use strict';
 
 import { readFileSync } from 'node:fs';
-import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 import { toAscii, toUnicode } from './index.js';
 
@@ -205,10 +204,11 @@ async function main(argv, io) {
 }
 
 /* c8 ignore start */
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+// `import.meta.main` rather than comparing import.meta.url against process.argv[1]:
+// npm installs the bin as a symlink (node_modules/.bin/idna-uts46-hx -> src/cli.js),
+// so argv[1] is the link while import.meta.url is the resolved target. Those never
+// match, and the CLI exited silently in every installed tree.
+if (import.meta.main) {
   main(process.argv.slice(2), {
     stdin: process.stdin,
     stdout: process.stdout,

--- a/test/test-cli.spec.js
+++ b/test/test-cli.spec.js
@@ -2,6 +2,9 @@
 
 import assert from 'assert';
 import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { main } from '../src/cli.js';
@@ -157,5 +160,27 @@ suite('cli', function () {
     });
     assert.strict.equal(result.status, 0);
     assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+  });
+
+  // npm installs the bin as a symlink in node_modules/.bin, so the path the CLI is
+  // invoked through is not the path the module resolves to. Detecting "am I the entry
+  // point?" by comparing process.argv[1] against import.meta.url therefore answered no
+  // in every installed tree, and the CLI exited silently. Invoke it through a symlink
+  // the way npm does.
+  test('runs when invoked through a symlink, as npm installs the bin', function () {
+    const dir = mkdtempSync(join(tmpdir(), 'idna-uts46-cli-'));
+    try {
+      const link = join(dir, 'idna-uts46-hx');
+      symlinkSync(CLI, link);
+      const result = spawnSync(
+        process.execPath,
+        [link, '-t', 'ascii', 'öbb.at'],
+        { encoding: 'utf8' },
+      );
+      assert.strict.equal(result.status, 0);
+      assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Jira: [RSRMID-3039](https://centralnic.atlassian.net/browse/RSRMID-3039)

Fixes a bug shipped in 6.2.0: **the CLI prints nothing and exits 0 in every installed tree.**

```console
$ npm install idna-uts46-hx@6.2.0
$ ./node_modules/.bin/idna-uts46-hx öbb.at
$ echo $?
0
```

## Cause

npm installs the bin as a symlink:

```
node_modules/.bin/idna-uts46-hx -> ../idna-uts46-hx/src/cli.js
```

The entry-point guard compared `import.meta.url` against `pathToFileURL(process.argv[1])`:

```
argv[1] as invoked : file:///…/node_modules/.bin/idna-uts46-hx
import.meta.url    : file:///…/node_modules/idna-uts46-hx/src/cli.js
```

`argv[1]` is the link the shell invoked, `import.meta.url` is the resolved target. They never match, so `main()` never ran and the process exited cleanly with no output. Running the file by its real path — which is exactly what the tests did — worked, which is why this shipped.

## Fix

`import.meta.main`, which answers precisely "am I the entry point?" and is unaffected by symlinks. It requires node >= 24.2; `engines` already demands `^24.15.0 || ^26.0.0`. The now-unused `pathToFileURL` import is dropped.

## Test plan

New regression test invokes the CLI through a symlink laid out the way npm does. Verified it fails against the old guard with exactly the production symptom before the fix:

```
AssertionError: Expected values to be strictly equal:
+ ''
- 'xn--bb-eka.at\n'
```

- `pnpm test` — 25 passing (24 + the regression test).
- `pnpm lint`, `pnpm prettier` — clean.
- End-to-end against a real install: `pnpm pack`, installed the tarball into a clean project, ran `node_modules/.bin/idna-uts46-hx` through the symlink. Output, stdin input, `--json`, `--version` and the exit-1 failure path all behave correctly.

Releases as 6.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-3039]: https://centralnic.atlassian.net/browse/RSRMID-3039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ