### PR TITLE
build(pnpm): drop the inert .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-auto-install-peers=true
-shamefully-hoist=true


### PR DESCRIPTION
Jira: [RSRMID-3041](https://centralnic.atlassian.net/browse/RSRMID-3041)

Removes `.npmrc`, which held only:

```ini
auto-install-peers=true
shamefully-hoist=true
```

## Why

Neither key does anything any more. The only tool still reading them is npm, which warns that a future major will stop tolerating unknown keys — so the file's whole remaining contribution is noise in the release log, plus an eventual failed publish.

The warnings show up twice per npm invocation during a release, as project *and* user config. That is one source, not two: [`set-npmrc-auth.js`](https://github.com/semantic-release/npm/blob/master/lib/set-npmrc-auth.js) reads the repo's `.npmrc`, concatenates it verbatim into a temp file, and runs npm with that as `NPM_CONFIG_USERCONFIG`.

```
npm warn Unknown project config "auto-install-peers". …
npm warn Unknown project config "shamefully-hoist". …
npm warn Unknown user config "auto-install-peers". …
npm warn Unknown user config "shamefully-hoist". …
```

## How they got here

Both arrived with `0880102` *"build(pnpm): initial switch"* (2025-11-20) as boilerplate of the npm → pnpm migration — bare commit message, no ticket reference, pushed straight to master. The work belongs to [RSRMID-2651](https://centralnic.atlassian.net/browse/RSRMID-2651) *"[CI/CD]: npm, vulnerable deps"*, whose comment 13 minutes before that commit records *"idna-uts46 (covered via dep upgrade & switch to pnpm)"*. That ticket is about vulnerable dependencies and replacing `package-lock.json`; neither key is mentioned in it or any of its comments, so no rationale for this repository was ever recorded.

They were valid when written — pnpm 10 still read settings from `.npmrc`. [pnpm 11](https://pnpm.io/blog/releases/11.0) stopped:

> pnpm no longer reads non-auth settings from `.npmrc`. […] Registry and auth settings — INI files. pnpm-specific settings — YAML files (`pnpm-workspace.yaml`, the new global `~/.config/pnpm/config.yaml`).

`devEngines` requires pnpm `^11.0.0`, so both went inert at that upgrade and nobody noticed, because nothing depended on the hoisting. Corroboration: `pnpm install` in this repo failed with `ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF` — a `node_modules` built while the key still counted, against a pnpm that no longer honours it. `auto-install-peers` was redundant even under pnpm 10, having defaulted to `true` for years.

## Deleted, not migrated

Moving `shamefullyHoist: true` into `pnpm-workspace.yaml` would *re-enable* a `node_modules` layout this repo has been building fine without — a real behaviour change. Removing dead config is not. `auto-install-peers` is redundant either way.

`EBADDEVENGINES` is untouched and stays: `@semantic-release/npm` shells out to `npm` while `devEngines` names pnpm. It is `onFail: "warn"` by design and cannot fail the release.

## Test plan

Fresh `pnpm install --frozen-lockfile` with the file gone:

- `pnpm test` — 25 passing.
- `pnpm lint`, `pnpm prettier` — clean.
- The tracked `dist/` files rebuild **byte-identical** — the only change in the working tree was the deletion itself.
- `npm pack` → installed the tarball into a clean project → works through both the bin symlink (`idna-uts46-hx öbb.at`, `--to ascii`) and the library API (`import { toAscii }`).
- Unknown-config warning count from npm: **4 → 0**.

`build` type, so semantic-release cuts no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-3041]: https://centralnic.atlassian.net/browse/RSRMID-3041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSRMID-2651]: https://centralnic.atlassian.net/browse/RSRMID-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ