### PR TITLE
style(prettier): drop the prettier config in favour of defaults

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# Commits that only reformat, and should be skipped by `git blame`.
+#
+# Github honours this file automatically. Locally, opt in once with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Add a commit here only if it changes formatting and nothing else.
+
+# style(prettier): drop the prettier config in favour of defaults
+e537fe6779728620e39c52c30e5c9448c5f223cc

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'daily'
+      interval: "daily"
     commit-message:
-      prefix: 'fix'
-      prefix-development: 'chore'
-      include: 'scope'
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
 
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'daily'
+      interval: "daily"
     commit-message:
-      prefix: 'chore'
-      include: 'scope'
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/daily-node-dependency-refresh.yml
+++ b/.github/workflows/daily-node-dependency-refresh.yml
@@ -2,7 +2,7 @@ name: Daily Node dependency refresh
 
 on:
   schedule:
-    - cron: '17 3 * * *'
+    - cron: "17 3 * * *"
   workflow_dispatch:
 
 permissions:
@@ -22,4 +22,4 @@ jobs:
       # Empty, so pnpm/action-setup resolves the version from
       # `devEngines.packageManager` in package.json rather than installing whatever
       # pnpm is newest. (RSRMID-3008)
-      pnpm-version: ''
+      pnpm-version: ""

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,5 +1,5 @@
 name: Quality
-'on':
+"on":
   pull_request:
     types:
       - opened
@@ -81,7 +81,7 @@ jobs:
           echo "ShellCheck completed."
 
   ci-success:
-    name: 'Quality: completed'
+    name: "Quality: completed"
     needs: [prettier, actionlint, shellcheck]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       # Empty, so pnpm/action-setup resolves the version from
       # `devEngines.packageManager` in package.json rather than installing whatever
       # pnpm is newest. (RSRMID-3008)
-      pnpm-version: ''
+      pnpm-version: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
       # Empty, so pnpm/action-setup resolves the version from
       # `devEngines.packageManager` in package.json rather than installing whatever
       # pnpm is newest. (RSRMID-3008)
-      pnpm-version: ''
+      pnpm-version: ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,11 @@ hand.
 
 ## Formatting
 
+There is no prettier config: the repository runs on prettier's defaults, so there is
+nothing to drift out of date. Bulk reformats are listed in `.git-blame-ignore-revs`;
+github skips them in blame automatically, and locally you opt in once with
+`git config blame.ignoreRevsFile .git-blame-ignore-revs`.
+
 Prettier owns everything it understands (Markdown, JSON, YAML). The husky pre-commit
 hook runs `lint-staged` over what you staged, so in practice formatting is fixed
 before it reaches CI. `pnpm install` installs the hook, through the `prepare` script.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,21 +1,21 @@
-const globals = require('globals');
-const recommended = require('@eslint/js').configs.recommended;
+const globals = require("globals");
+const recommended = require("@eslint/js").configs.recommended;
 
 module.exports = [
   {
     ignores: [
-      'coverage/**',
-      'dist/**',
-      'test/index.bundle.js',
-      'test/index.mjs',
-      'test/mocha.css',
+      "coverage/**",
+      "dist/**",
+      "test/index.bundle.js",
+      "test/index.mjs",
+      "test/mocha.css",
     ],
   },
   {
     ...recommended,
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: 'module',
+      sourceType: "module",
       globals: {
         ...globals.es6,
         ...globals.node,
@@ -23,7 +23,7 @@ module.exports = [
     },
   },
   {
-    files: ['test/*.js'],
+    files: ["test/*.js"],
     languageOptions: {
       globals: {
         ...globals.mocha,

--- a/package.json
+++ b/package.json
@@ -81,10 +81,5 @@
     "**/*": [
       "prettier --write --ignore-unknown"
     ]
-  },
-  "prettier": {
-    "trailingComma": "all",
-    "tabWidth": 2,
-    "singleQuote": true
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,8 +5,8 @@ allowBuilds:
   esbuild: true
 
 overrides:
-  diff@>=6.0.0 <8.0.3: '>=8.0.3'
-  serialize-javascript@<=7.0.2: '>=7.0.3'
+  diff@>=6.0.0 <8.0.3: ">=8.0.3"
+  serialize-javascript@<=7.0.2: ">=7.0.3"
 
 # Nothing here is installed until it is at least a day old. This is a supply-chain
 # control, not a tidiness rule: the npm attacks that actually hurt people publish a

--- a/rollup-esm.config.mjs
+++ b/rollup-esm.config.mjs
@@ -1,24 +1,24 @@
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import terser from '@rollup/plugin-terser';
-import bundleSize from 'rollup-plugin-bundle-size';
-import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json';
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import terser from "@rollup/plugin-terser";
+import bundleSize from "rollup-plugin-bundle-size";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
 
 export default {
-  input: 'src/index.js',
+  input: "src/index.js",
   output: [
     {
-      file: 'dist/index.bundle.js',
-      format: 'iife',
-      name: 'idnaUts46',
+      file: "dist/index.bundle.js",
+      format: "iife",
+      name: "idnaUts46",
     },
     {
-      file: 'dist/index.cjs',
-      format: 'cjs',
+      file: "dist/index.cjs",
+      format: "cjs",
     },
     {
-      file: 'dist/index.mjs',
-      format: 'es',
+      file: "dist/index.mjs",
+      format: "es",
     },
   ],
   plugins: [nodeResolve(), commonjs(), json(), terser(), bundleSize()],

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-'use strict';
+"use strict";
 
-import { readFileSync } from 'node:fs';
-import { parseArgs } from 'node:util';
-import { toAscii, toUnicode } from './index.js';
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { toAscii, toUnicode } from "./index.js";
 
 const pkg = JSON.parse(
-  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 );
 
 const USAGE = `Usage: idna-uts46-hx [options] [domain ...]
@@ -40,58 +40,58 @@ Examples:
 `;
 
 const OPTIONS = {
-  to: { type: 'string', short: 't', default: 'both' },
-  json: { type: 'boolean', short: 'j', default: false },
-  separator: { type: 'string', short: 's', default: '\t' },
-  transitional: { type: 'boolean', default: false },
-  'no-transitional': { type: 'boolean', default: false },
-  std3: { type: 'boolean', default: false },
-  'verify-dns-length': { type: 'boolean', default: false },
-  'check-hyphens': { type: 'boolean', default: false },
-  'check-bidi': { type: 'boolean', default: false },
-  'check-joiners': { type: 'boolean', default: false },
-  help: { type: 'boolean', short: 'h', default: false },
-  version: { type: 'boolean', short: 'v', default: false },
+  to: { type: "string", short: "t", default: "both" },
+  json: { type: "boolean", short: "j", default: false },
+  separator: { type: "string", short: "s", default: "\t" },
+  transitional: { type: "boolean", default: false },
+  "no-transitional": { type: "boolean", default: false },
+  std3: { type: "boolean", default: false },
+  "verify-dns-length": { type: "boolean", default: false },
+  "check-hyphens": { type: "boolean", default: false },
+  "check-bidi": { type: "boolean", default: false },
+  "check-joiners": { type: "boolean", default: false },
+  help: { type: "boolean", short: "h", default: false },
+  version: { type: "boolean", short: "v", default: false },
 };
 
 class UsageError extends Error {}
 
 function toTr46Options(values) {
   const options = {};
-  if (values.transitional && values['no-transitional']) {
+  if (values.transitional && values["no-transitional"]) {
     throw new UsageError(
-      'Options --transitional and --no-transitional are mutually exclusive.',
+      "Options --transitional and --no-transitional are mutually exclusive.",
     );
   }
   if (values.transitional) {
     options.transitionalProcessing = true;
   }
-  if (values['no-transitional']) {
+  if (values["no-transitional"]) {
     options.transitionalProcessing = false;
   }
   if (values.std3) {
     options.useSTD3ASCIIRules = true;
   }
-  if (values['verify-dns-length']) {
+  if (values["verify-dns-length"]) {
     options.verifyDNSLength = true;
   }
-  if (values['check-hyphens']) {
+  if (values["check-hyphens"]) {
     options.checkHyphens = true;
   }
-  if (values['check-bidi']) {
+  if (values["check-bidi"]) {
     options.checkBidi = true;
   }
-  if (values['check-joiners']) {
+  if (values["check-joiners"]) {
     options.checkJoiners = true;
   }
   return options;
 }
 
 function convertOne(domainName, mode, options) {
-  if (mode === 'ascii') {
+  if (mode === "ascii") {
     return { input: domainName, PC: toAscii(domainName, options) };
   }
-  if (mode === 'unicode') {
+  if (mode === "unicode") {
     return { input: domainName, IDN: toUnicode(domainName, options) };
   }
   const idn = toUnicode(domainName, options);
@@ -99,10 +99,10 @@ function convertOne(domainName, mode, options) {
 }
 
 function formatText(result, mode, separator) {
-  if (mode === 'ascii') {
+  if (mode === "ascii") {
     return result.PC;
   }
-  if (mode === 'unicode') {
+  if (mode === "unicode") {
     return result.IDN;
   }
   return `${result.IDN}${separator}${result.PC}`;
@@ -110,13 +110,13 @@ function formatText(result, mode, separator) {
 
 function readStdin(stream) {
   return new Promise((resolve, reject) => {
-    let data = '';
-    stream.setEncoding('utf8');
-    stream.on('data', (chunk) => {
+    let data = "";
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
       data += chunk;
     });
-    stream.on('end', () => resolve(data));
-    stream.on('error', reject);
+    stream.on("end", () => resolve(data));
+    stream.on("error", reject);
   });
 }
 
@@ -125,7 +125,7 @@ async function collectDomainNames(positionals, stdin) {
     return positionals;
   }
   if (stdin.isTTY) {
-    throw new UsageError('No domain names given.');
+    throw new UsageError("No domain names given.");
   }
   return (await readStdin(stdin))
     .split(/\r?\n/)
@@ -156,7 +156,7 @@ async function run(argv, io) {
   }
 
   const mode = values.to.toLowerCase();
-  if (!['ascii', 'unicode', 'both'].includes(mode)) {
+  if (!["ascii", "unicode", "both"].includes(mode)) {
     throw new UsageError(
       `Unknown mode "${values.to}", expected one of: ascii, unicode, both.`,
     );

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import tr46 from 'tr46';
+import tr46 from "tr46";
 
 function getDefaultOptions(domainName) {
   return {

--- a/test/test-amd.html
+++ b/test/test-amd.html
@@ -19,10 +19,10 @@
     </style>
     <script>
       function start() {
-        const eL = document.getElementById('convert');
+        const eL = document.getElementById("convert");
         if (!idnaUts46) {
           debugger;
-          alert('... Failed loading IDN Converter');
+          alert("... Failed loading IDN Converter");
           return;
         }
         eL.innerHTML = '<h1 class="ok">... IDN Converter loaded</b><h1>';
@@ -30,151 +30,151 @@
         const uts46 = idnaUts46;
         const data = {
           convert: {
-            'öbb.at': 'xn--bb-eka.at',
-            'faß.de': 'xn--fa-hia.de',
-            'xn----5da7e.de': 'xn----zfa7e.de',
+            "öbb.at": "xn--bb-eka.at",
+            "faß.de": "xn--fa-hia.de",
+            "xn----5da7e.de": "xn----zfa7e.de",
           },
           toAscii: {
-            '': '',
-            'faß.de': 'fass.de',
-            '\ud83d\udca9': 'xn--ls8h',
-            '\ud87e\udcca': 'xn--w60j',
-            '\udb40\udd00\ud87e\udcca': 'xn--w60j',
+            "": "",
+            "faß.de": "fass.de",
+            "\ud83d\udca9": "xn--ls8h",
+            "\ud87e\udcca": "xn--w60j",
+            "\udb40\udd00\ud87e\udcca": "xn--w60j",
           },
           toAsciiTransitional1: {
-            'faß.de': 'fass.de',
-            'fass.de': 'fass.de',
-            'xn--fa-hia.de': 'xn--fa-hia.de',
-            'fäß.de': 'xn--fss-qla.de',
-            '₹.com': 'xn--yzg.com',
-            '𑀓.com': 'xn--n00d.com',
-            a‌b: 'ab',
-            'xn--ab-j1t': 'xn--ab-j1t',
-            'öbb.at': 'xn--bb-eka.at',
-            'ÖBB.at': 'xn--bb-eka.at',
-            'ȡog.de': 'xn--og-09a.de',
-            '☕.de': 'xn--53h.de',
-            'I♥NY.de': 'xn--iny-zx5a.de',
-            'ＡＢＣ・日本.co.jp': 'xn--abc-rs4b422ycvb.co.jp',
-            '日本｡co｡jp': 'xn--wgv71a.co.jp',
-            '日本｡co．jp': 'xn--wgv71a.co.jp',
-            'x\u0327\u0301.de': 'xn--x-xbb7i.de',
-            'x\u0301\u0327.de': 'xn--x-xbb7i.de',
-            'σόλος.gr': 'xn--wxaikc6b.gr',
-            'Σόλος.gr': 'xn--wxaikc6b.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de': 'xn--wxaikc6b.xn--gr-gtd9a1b0g.de',
-            'عربي.de': 'xn--ngbrx4e.de',
-            'نامهای.de': 'xn--mgba3gch31f.de',
-            'نامه\u200Cای.de': 'xn--mgba3gch31f.de',
+            "faß.de": "fass.de",
+            "fass.de": "fass.de",
+            "xn--fa-hia.de": "xn--fa-hia.de",
+            "fäß.de": "xn--fss-qla.de",
+            "₹.com": "xn--yzg.com",
+            "𑀓.com": "xn--n00d.com",
+            a‌b: "ab",
+            "xn--ab-j1t": "xn--ab-j1t",
+            "öbb.at": "xn--bb-eka.at",
+            "ÖBB.at": "xn--bb-eka.at",
+            "ȡog.de": "xn--og-09a.de",
+            "☕.de": "xn--53h.de",
+            "I♥NY.de": "xn--iny-zx5a.de",
+            "ＡＢＣ・日本.co.jp": "xn--abc-rs4b422ycvb.co.jp",
+            "日本｡co｡jp": "xn--wgv71a.co.jp",
+            "日本｡co．jp": "xn--wgv71a.co.jp",
+            "x\u0327\u0301.de": "xn--x-xbb7i.de",
+            "x\u0301\u0327.de": "xn--x-xbb7i.de",
+            "σόλος.gr": "xn--wxaikc6b.gr",
+            "Σόλος.gr": "xn--wxaikc6b.gr",
+            "ΣΌΛΟΣ.grﻋﺮﺑﻲ.de": "xn--wxaikc6b.xn--gr-gtd9a1b0g.de",
+            "عربي.de": "xn--ngbrx4e.de",
+            "نامهای.de": "xn--mgba3gch31f.de",
+            "نامه\u200Cای.de": "xn--mgba3gch31f.de",
           },
           toAsciiTransitional0: {
-            'xn--bb-eka.at': 'xn--bb-eka.at',
-            'XN--BB-EKA.AT': 'xn--bb-eka.at',
-            'faß.de': 'xn--fa-hia.de',
-            'fass.de': 'fass.de',
-            'xn--fa-hia.de': 'xn--fa-hia.de',
-            'not=std3': 'not=std3',
-            'öbb.at': 'xn--bb-eka.at',
-            'fäß.de': 'xn--f-qfao.de',
-            '₹.com': 'xn--yzg.com',
-            '𑀓.com': 'xn--n00d.com',
-            a‌b: 'xn--ab-j1t',
-            'xn--ab-j1t': 'xn--ab-j1t',
-            'ÖBB.at': 'xn--bb-eka.at',
-            'ȡog.de': 'xn--og-09a.de',
-            '☕.de': 'xn--53h.de',
-            'I♥NY.de': 'xn--iny-zx5a.de',
-            'ＡＢＣ・日本.co.jp': 'xn--abc-rs4b422ycvb.co.jp',
-            '日本｡co｡jp': 'xn--wgv71a.co.jp',
-            '日本｡co．jp': 'xn--wgv71a.co.jp',
-            'x\u0327\u0301.de': 'xn--x-xbb7i.de',
-            'x\u0301\u0327.de': 'xn--x-xbb7i.de',
-            'σόλος.gr': 'xn--wxaijb9b.gr',
-            'Σόλος.gr': 'xn--wxaijb9b.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de': 'xn--wxaikc6b.xn--gr-gtd9a1b0g.de',
-            'عربي.de': 'xn--ngbrx4e.de',
-            'نامهای.de': 'xn--mgba3gch31f.de',
-            'نامه\u200Cای.de': 'xn--mgba3gch31f060k.de',
+            "xn--bb-eka.at": "xn--bb-eka.at",
+            "XN--BB-EKA.AT": "xn--bb-eka.at",
+            "faß.de": "xn--fa-hia.de",
+            "fass.de": "fass.de",
+            "xn--fa-hia.de": "xn--fa-hia.de",
+            "not=std3": "not=std3",
+            "öbb.at": "xn--bb-eka.at",
+            "fäß.de": "xn--f-qfao.de",
+            "₹.com": "xn--yzg.com",
+            "𑀓.com": "xn--n00d.com",
+            a‌b: "xn--ab-j1t",
+            "xn--ab-j1t": "xn--ab-j1t",
+            "ÖBB.at": "xn--bb-eka.at",
+            "ȡog.de": "xn--og-09a.de",
+            "☕.de": "xn--53h.de",
+            "I♥NY.de": "xn--iny-zx5a.de",
+            "ＡＢＣ・日本.co.jp": "xn--abc-rs4b422ycvb.co.jp",
+            "日本｡co｡jp": "xn--wgv71a.co.jp",
+            "日本｡co．jp": "xn--wgv71a.co.jp",
+            "x\u0327\u0301.de": "xn--x-xbb7i.de",
+            "x\u0301\u0327.de": "xn--x-xbb7i.de",
+            "σόλος.gr": "xn--wxaijb9b.gr",
+            "Σόλος.gr": "xn--wxaijb9b.gr",
+            "ΣΌΛΟΣ.grﻋﺮﺑﻲ.de": "xn--wxaikc6b.xn--gr-gtd9a1b0g.de",
+            "عربي.de": "xn--ngbrx4e.de",
+            "نامهای.de": "xn--mgba3gch31f.de",
+            "نامه\u200Cای.de": "xn--mgba3gch31f060k.de",
           },
-          toAsciithrows: [String.fromCodePoint(0xd0000), '\u0080.com'],
-          toAsciiTransitional1throws: ['xn--a.com', '日本⒈co．jp'],
+          toAsciithrows: [String.fromCodePoint(0xd0000), "\u0080.com"],
+          toAsciiTransitional1throws: ["xn--a.com", "日本⒈co．jp"],
           toAsciiTransitional0throws: [
-            '\u0080.com',
-            'xn--a.com',
-            '日本⒈co．jp',
+            "\u0080.com",
+            "xn--a.com",
+            "日本⒈co．jp",
           ],
-          toAsciiUseStd3ASCIIthrows: ['not=std3'],
+          toAsciiUseStd3ASCIIthrows: ["not=std3"],
           toAsciiVerifyDnsLength0: {
-            '': '',
+            "": "",
           },
           toAsciiVerifyDnsLength1throws: [
-            '',
-            'this..is.almost.right',
-            'a.'.repeat(252 / 2) + 'aa',
-            'a'.repeat(64),
+            "",
+            "this..is.almost.right",
+            "a.".repeat(252 / 2) + "aa",
+            "a".repeat(64),
           ],
           toAsciiVerifyDnsLength1throwsnot: [
-            'a.'.repeat(252 / 2) + 'a',
-            'a'.repeat(63),
+            "a.".repeat(252 / 2) + "a",
+            "a".repeat(63),
           ],
           toUnicode: {
-            'öbb.at': 'öbb.at',
-            'Öbb.at': 'öbb.at',
-            'ÖBB.at': 'öbb.at',
-            'O\u0308bb.at': 'öbb.at',
-            'xn--bb-eka.at': 'öbb.at',
-            'xn----5da7e.de': 'ä-ü.de',
-            'faß.de': 'faß.de',
-            'fass.de': 'fass.de',
-            'xn--fa-hia.de': 'faß.de',
-            'not=std3': 'not=std3',
-            '\ud83d\udca9': '\ud83d\udca9',
-            '\ud87e\udcca': '\ud84c\udc0a',
-            '\udb40\udd00\ud87e\udcca': '\ud84c\udc0a',
-            'fäß.de': 'fäß.de',
-            '₹.com': '₹.com',
-            '𑀓.com': '𑀓.com',
-            a‌b: 'a\u200Cb',
-            'xn--ab-j1t': 'a\u200Cb',
-            'ȡog.de': 'ȡog.de',
-            '☕.de': '☕.de',
-            'I♥NY.de': 'i♥ny.de',
-            'ＡＢＣ・日本.co.jp': 'abc・日本.co.jp',
-            '日本｡co｡jp': '日本.co.jp',
-            '日本｡co．jp': '日本.co.jp',
-            'x\u0327\u0301.de': 'x̧́.de',
-            'x\u0301\u0327.de': 'x̧́.de',
-            'σόλος.gr': 'σόλος.gr',
-            'Σόλος.gr': 'σόλος.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de': 'σόλοσ.grعربي.de',
-            'عربي.de': 'عربي.de',
-            'نامهای.de': 'نامهای.de',
-            'نامه\u200Cای.de': 'نامه‌ای.de',
+            "öbb.at": "öbb.at",
+            "Öbb.at": "öbb.at",
+            "ÖBB.at": "öbb.at",
+            "O\u0308bb.at": "öbb.at",
+            "xn--bb-eka.at": "öbb.at",
+            "xn----5da7e.de": "ä-ü.de",
+            "faß.de": "faß.de",
+            "fass.de": "fass.de",
+            "xn--fa-hia.de": "faß.de",
+            "not=std3": "not=std3",
+            "\ud83d\udca9": "\ud83d\udca9",
+            "\ud87e\udcca": "\ud84c\udc0a",
+            "\udb40\udd00\ud87e\udcca": "\ud84c\udc0a",
+            "fäß.de": "fäß.de",
+            "₹.com": "₹.com",
+            "𑀓.com": "𑀓.com",
+            a‌b: "a\u200Cb",
+            "xn--ab-j1t": "a\u200Cb",
+            "ȡog.de": "ȡog.de",
+            "☕.de": "☕.de",
+            "I♥NY.de": "i♥ny.de",
+            "ＡＢＣ・日本.co.jp": "abc・日本.co.jp",
+            "日本｡co｡jp": "日本.co.jp",
+            "日本｡co．jp": "日本.co.jp",
+            "x\u0327\u0301.de": "x̧́.de",
+            "x\u0301\u0327.de": "x̧́.de",
+            "σόλος.gr": "σόλος.gr",
+            "Σόλος.gr": "σόλος.gr",
+            "ΣΌΛΟΣ.grﻋﺮﺑﻲ.de": "σόλοσ.grعربي.de",
+            "عربي.de": "عربي.de",
+            "نامهای.de": "نامهای.de",
+            "نامه\u200Cای.de": "نامه‌ای.de",
           },
           toUnicodethrows: [
             String.fromCodePoint(0xd0000),
-            '\u0080.com',
-            'xn--a.com',
-            '日本⒈co．jp',
+            "\u0080.com",
+            "xn--a.com",
+            "日本⒈co．jp",
           ],
-          toUnicodeUseStd3ASCII1throws: ['not=std3'],
+          toUnicodeUseStd3ASCII1throws: ["not=std3"],
         };
         //TODO xo linting as eslint replacement
 
         // --- method convert
-        eL.innerHTML += '<h2>Method convert</h2>';
+        eL.innerHTML += "<h2>Method convert</h2>";
         let tmp = data.convert;
         Object.keys(tmp).forEach((key) => {
           const val = uts46.convert(key);
           const ok = key === val.IDN && tmp[key] === val.PC;
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val.PC}</div>`;
         });
 
         // --- method toAscii
         eL.innerHTML +=
-          '<h2>Method toAscii (transitionalProcessing: true)</h2>';
+          "<h2>Method toAscii (transitionalProcessing: true)</h2>";
         tmp = data.toAscii;
         Object.keys(tmp).forEach((key) => {
           let val = uts46.toAscii(key, { transitionalProcessing: true });
@@ -185,35 +185,35 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: false)
-        eL.innerHTML += '<h3>... transitionalProcessing: false</h3>';
+        eL.innerHTML += "<h3>... transitionalProcessing: false</h3>";
         tmp = data.toAsciiTransitional0;
         Object.keys(tmp).forEach((key) => {
           const val = uts46.toAscii(key, { transitionalProcessing: false });
           const ok = tmp[key] === val;
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: true)
-        eL.innerHTML += '<h3>... transitionalProcessing: true</h3>';
+        eL.innerHTML += "<h3>... transitionalProcessing: true</h3>";
         tmp = data.toAsciiTransitional1;
         Object.keys(tmp).forEach((key) => {
           const val = uts46.toAscii(key, { transitionalProcessing: true });
           const ok = tmp[key] === val;
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (throws)
-        eL.innerHTML += '<h3>... throws</h3>';
+        eL.innerHTML += "<h3>... throws</h3>";
         tmp = data.toAsciithrows;
         tmp.forEach((val) => {
           let ok;
@@ -226,13 +226,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: true & throws)
-        eL.innerHTML += '<h3>... throws & transitionalProcessing: true</h3>';
+        eL.innerHTML += "<h3>... throws & transitionalProcessing: true</h3>";
         tmp = data.toAsciiTransitional1throws;
         tmp.forEach((val) => {
           let ok;
@@ -245,13 +245,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: false & throws)
-        eL.innerHTML += '<h3>... throws & transitionalProcessing: false</h3>';
+        eL.innerHTML += "<h3>... throws & transitionalProcessing: false</h3>";
         tmp = data.toAsciiTransitional0throws;
         tmp.forEach((val) => {
           let ok;
@@ -264,13 +264,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (useSTD3ASCIIRules: true, throws)
-        eL.innerHTML += '<h3>... throws & useSTD3ASCIIRules: true</h3>';
+        eL.innerHTML += "<h3>... throws & useSTD3ASCIIRules: true</h3>";
         tmp = data.toAsciiUseStd3ASCIIthrows;
         tmp.forEach((val) => {
           let ok;
@@ -280,13 +280,13 @@
           } catch (e) {
             ok = true;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (verifyDNSLength: false)
-        eL.innerHTML += '<h3>... verifyDNSLength: false</h3>';
+        eL.innerHTML += "<h3>... verifyDNSLength: false</h3>";
         tmp = data.toAsciiVerifyDnsLength0;
         Object.keys(tmp).forEach((key) => {
           let val = uts46.toAscii(key, { verifyDNSLength: false });
@@ -297,13 +297,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (verifyDNSLength: true, throws)
-        eL.innerHTML += '<h3>... throws & verifyDNSLength: true</h3>';
+        eL.innerHTML += "<h3>... throws & verifyDNSLength: true</h3>";
         tmp = data.toAsciiVerifyDnsLength1throws;
         tmp.forEach((val) => {
           let ok;
@@ -316,13 +316,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (verifyDNSLength: true, throws not)
-        eL.innerHTML += '<h3>... throws not & verifyDNSLength: true</h3>';
+        eL.innerHTML += "<h3>... throws not & verifyDNSLength: true</h3>";
         tmp = data.toAsciiVerifyDnsLength1throwsnot;
         tmp.forEach((val) => {
           let ok;
@@ -332,14 +332,14 @@
           } catch (e) {
             ok = false;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toUnicode
         eL.innerHTML +=
-          '<h2>Method toUnicode (transitionalProcessing: false)</h2>';
+          "<h2>Method toUnicode (transitionalProcessing: false)</h2>";
         tmp = data.toUnicode;
         Object.keys(tmp).forEach((key) => {
           let val = uts46.toUnicode(key, { transitionalProcessing: false });
@@ -350,13 +350,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toUnicode (throws)
-        eL.innerHTML += '<h3>... throws</h3>';
+        eL.innerHTML += "<h3>... throws</h3>";
         tmp = data.toUnicodethrows;
         tmp.forEach((val) => {
           let ok;
@@ -369,13 +369,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toUnicode (useSTD3ASCIIRules: true, throws)
-        eL.innerHTML += '<h3>... useSTD3ASCIIRules: true & throws</h3>';
+        eL.innerHTML += "<h3>... useSTD3ASCIIRules: true & throws</h3>";
         tmp = data.toUnicodeUseStd3ASCII1throws;
         tmp.forEach((val) => {
           let ok;
@@ -388,8 +388,8 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
       }

--- a/test/test-cli.spec.js
+++ b/test/test-cli.spec.js
@@ -1,15 +1,15 @@
-'use strict';
+"use strict";
 
-import assert from 'assert';
-import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { Readable } from 'node:stream';
-import { fileURLToPath } from 'node:url';
-import { main } from '../src/cli.js';
+import assert from "assert";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+import { main } from "../src/cli.js";
 
-const CLI = fileURLToPath(new URL('../src/cli.js', import.meta.url));
+const CLI = fileURLToPath(new URL("../src/cli.js", import.meta.url));
 
 function collector() {
   const chunks = [];
@@ -19,7 +19,7 @@ function collector() {
       return true;
     },
     get text() {
-      return chunks.join('');
+      return chunks.join("");
     },
   };
 }
@@ -35,131 +35,131 @@ async function cli(args, stdin = null) {
   return { code, stdout: stdout.text, stderr: stderr.text };
 }
 
-suite('cli', function () {
-  test('converts to both representations by default', async function () {
-    const result = await cli(['öbb.at', 'xn----5da7e.de']);
+suite("cli", function () {
+  test("converts to both representations by default", async function () {
+    const result = await cli(["öbb.at", "xn----5da7e.de"]);
     assert.strict.equal(result.code, 0);
     assert.strict.equal(
       result.stdout,
-      'öbb.at\txn--bb-eka.at\nä-ü.de\txn----zfa7e.de\n',
+      "öbb.at\txn--bb-eka.at\nä-ü.de\txn----zfa7e.de\n",
     );
-    assert.strict.equal(result.stderr, '');
+    assert.strict.equal(result.stderr, "");
   });
 
-  test('honors the custom separator', async function () {
-    const result = await cli(['--separator', ' => ', 'öbb.at']);
-    assert.strict.equal(result.stdout, 'öbb.at => xn--bb-eka.at\n');
+  test("honors the custom separator", async function () {
+    const result = await cli(["--separator", " => ", "öbb.at"]);
+    assert.strict.equal(result.stdout, "öbb.at => xn--bb-eka.at\n");
   });
 
-  test('converts to ascii only', async function () {
-    const result = await cli(['--to', 'ascii', 'öbb.at']);
+  test("converts to ascii only", async function () {
+    const result = await cli(["--to", "ascii", "öbb.at"]);
     assert.strict.equal(result.code, 0);
-    assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+    assert.strict.equal(result.stdout, "xn--bb-eka.at\n");
   });
 
-  test('converts to unicode only', async function () {
-    const result = await cli(['-t', 'UNICODE', 'xn--bb-eka.at']);
+  test("converts to unicode only", async function () {
+    const result = await cli(["-t", "UNICODE", "xn--bb-eka.at"]);
     assert.strict.equal(result.code, 0);
-    assert.strict.equal(result.stdout, 'öbb.at\n');
+    assert.strict.equal(result.stdout, "öbb.at\n");
   });
 
-  test('applies transitional processing switches', async function () {
+  test("applies transitional processing switches", async function () {
     assert.strict.equal(
-      (await cli(['-t', 'ascii', '--transitional', 'faß.de'])).stdout,
-      'fass.de\n',
+      (await cli(["-t", "ascii", "--transitional", "faß.de"])).stdout,
+      "fass.de\n",
     );
     assert.strict.equal(
-      (await cli(['-t', 'ascii', '--no-transitional', 'faß.de'])).stdout,
-      'xn--fa-hia.de\n',
+      (await cli(["-t", "ascii", "--no-transitional", "faß.de"])).stdout,
+      "xn--fa-hia.de\n",
     );
   });
 
-  test('passes tr46 flags through', async function () {
+  test("passes tr46 flags through", async function () {
     const result = await cli([
-      '-t',
-      'ascii',
-      '--std3',
-      '--verify-dns-length',
-      '--check-hyphens',
-      '--check-bidi',
-      '--check-joiners',
-      'öbb.at',
+      "-t",
+      "ascii",
+      "--std3",
+      "--verify-dns-length",
+      "--check-hyphens",
+      "--check-bidi",
+      "--check-joiners",
+      "öbb.at",
     ]);
     assert.strict.equal(result.code, 0);
-    assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+    assert.strict.equal(result.stdout, "xn--bb-eka.at\n");
   });
 
-  test('reads domain names from stdin', async function () {
-    const result = await cli(['-t', 'ascii'], 'öbb.at\n\n  faß.de  \r\n');
+  test("reads domain names from stdin", async function () {
+    const result = await cli(["-t", "ascii"], "öbb.at\n\n  faß.de  \r\n");
     assert.strict.equal(result.code, 0);
-    assert.strict.equal(result.stdout, 'xn--bb-eka.at\nxn--fa-hia.de\n');
+    assert.strict.equal(result.stdout, "xn--bb-eka.at\nxn--fa-hia.de\n");
   });
 
-  test('emits json', async function () {
-    const result = await cli(['--json', 'öbb.at']);
+  test("emits json", async function () {
+    const result = await cli(["--json", "öbb.at"]);
     assert.strict.deepEqual(JSON.parse(result.stdout), [
-      { input: 'öbb.at', IDN: 'öbb.at', PC: 'xn--bb-eka.at' },
+      { input: "öbb.at", IDN: "öbb.at", PC: "xn--bb-eka.at" },
     ]);
   });
 
-  test('reports conversion failures and exits with 1', async function () {
+  test("reports conversion failures and exits with 1", async function () {
     const invalid = String.fromCodePoint(0xd0000);
-    const result = await cli([invalid, 'öbb.at']);
+    const result = await cli([invalid, "öbb.at"]);
     assert.strict.equal(result.code, 1);
-    assert.strict.equal(result.stdout, 'öbb.at\txn--bb-eka.at\n');
+    assert.strict.equal(result.stdout, "öbb.at\txn--bb-eka.at\n");
     assert.strict.match(result.stderr, /Unable to translate/);
   });
 
-  test('reports conversion failures in json mode', async function () {
+  test("reports conversion failures in json mode", async function () {
     const invalid = String.fromCodePoint(0xd0000);
-    const result = await cli(['--json', invalid]);
+    const result = await cli(["--json", invalid]);
     assert.strict.equal(result.code, 1);
     const parsed = JSON.parse(result.stdout);
     assert.strict.equal(parsed[0].input, invalid);
     assert.strict.match(parsed[0].error, /Unable to translate/);
   });
 
-  test('rejects an unknown mode', async function () {
-    const result = await cli(['--to', 'klingon', 'öbb.at']);
+  test("rejects an unknown mode", async function () {
+    const result = await cli(["--to", "klingon", "öbb.at"]);
     assert.strict.equal(result.code, 2);
-    assert.strict.equal(result.stdout, '');
+    assert.strict.equal(result.stdout, "");
     assert.strict.match(result.stderr, /Unknown mode "klingon"/);
   });
 
-  test('rejects an unknown option', async function () {
-    const result = await cli(['--nope']);
+  test("rejects an unknown option", async function () {
+    const result = await cli(["--nope"]);
     assert.strict.equal(result.code, 2);
     assert.strict.match(result.stderr, /Usage:/);
   });
 
-  test('rejects contradicting transitional switches', async function () {
-    const result = await cli(['--transitional', '--no-transitional', 'öbb.at']);
+  test("rejects contradicting transitional switches", async function () {
+    const result = await cli(["--transitional", "--no-transitional", "öbb.at"]);
     assert.strict.equal(result.code, 2);
     assert.strict.match(result.stderr, /mutually exclusive/);
   });
 
-  test('rejects a missing domain name on a tty', async function () {
+  test("rejects a missing domain name on a tty", async function () {
     const result = await cli([]);
     assert.strict.equal(result.code, 2);
     assert.strict.match(result.stderr, /No domain names given/);
   });
 
-  test('prints help and version', async function () {
-    const help = await cli(['--help']);
+  test("prints help and version", async function () {
+    const help = await cli(["--help"]);
     assert.strict.equal(help.code, 0);
     assert.strict.match(help.stdout, /^Usage: idna-uts46-hx/);
 
-    const version = await cli(['--version']);
+    const version = await cli(["--version"]);
     assert.strict.equal(version.code, 0);
     assert.strict.match(version.stdout, /^\d+\.\d+\.\d+/);
   });
 
-  test('runs as an executable script', function () {
-    const result = spawnSync(process.execPath, [CLI, '-t', 'ascii', 'öbb.at'], {
-      encoding: 'utf8',
+  test("runs as an executable script", function () {
+    const result = spawnSync(process.execPath, [CLI, "-t", "ascii", "öbb.at"], {
+      encoding: "utf8",
     });
     assert.strict.equal(result.status, 0);
-    assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+    assert.strict.equal(result.stdout, "xn--bb-eka.at\n");
   });
 
   // npm installs the bin as a symlink in node_modules/.bin, so the path the CLI is
@@ -167,18 +167,18 @@ suite('cli', function () {
   // point?" by comparing process.argv[1] against import.meta.url therefore answered no
   // in every installed tree, and the CLI exited silently. Invoke it through a symlink
   // the way npm does.
-  test('runs when invoked through a symlink, as npm installs the bin', function () {
-    const dir = mkdtempSync(join(tmpdir(), 'idna-uts46-cli-'));
+  test("runs when invoked through a symlink, as npm installs the bin", function () {
+    const dir = mkdtempSync(join(tmpdir(), "idna-uts46-cli-"));
     try {
-      const link = join(dir, 'idna-uts46-hx');
+      const link = join(dir, "idna-uts46-hx");
       symlinkSync(CLI, link);
       const result = spawnSync(
         process.execPath,
-        [link, '-t', 'ascii', 'öbb.at'],
-        { encoding: 'utf8' },
+        [link, "-t", "ascii", "öbb.at"],
+        { encoding: "utf8" },
       );
       assert.strict.equal(result.status, 0);
-      assert.strict.equal(result.stdout, 'xn--bb-eka.at\n');
+      assert.strict.equal(result.stdout, "xn--bb-eka.at\n");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/test-esm.html
+++ b/test/test-esm.html
@@ -17,159 +17,159 @@
       }
     </style>
     <script type="module">
-      import * as uts46 from './index.mjs';
+      import * as uts46 from "./index.mjs";
 
       export function start() {
-        const eL = document.getElementById('convert');
+        const eL = document.getElementById("convert");
         eL.innerHTML = '<h1 class="ok">... IDN Converter loaded</b><h1>';
 
         const data = {
           convert: {
-            'öbb.at': 'xn--bb-eka.at',
-            'faß.de': 'xn--fa-hia.de',
-            'xn----5da7e.de': 'xn----zfa7e.de',
+            "öbb.at": "xn--bb-eka.at",
+            "faß.de": "xn--fa-hia.de",
+            "xn----5da7e.de": "xn----zfa7e.de",
           },
           toAscii: {
-            '': '',
-            'faß.de': 'fass.de',
-            '\ud83d\udca9': 'xn--ls8h',
-            '\ud87e\udcca': 'xn--w60j',
-            '\udb40\udd00\ud87e\udcca': 'xn--w60j',
+            "": "",
+            "faß.de": "fass.de",
+            "\ud83d\udca9": "xn--ls8h",
+            "\ud87e\udcca": "xn--w60j",
+            "\udb40\udd00\ud87e\udcca": "xn--w60j",
           },
           toAsciiTransitional1: {
-            'faß.de': 'fass.de',
-            'fass.de': 'fass.de',
-            'xn--fa-hia.de': 'xn--fa-hia.de',
-            'fäß.de': 'xn--fss-qla.de',
-            '₹.com': 'xn--yzg.com',
-            '𑀓.com': 'xn--n00d.com',
-            a‌b: 'ab',
-            'xn--ab-j1t': 'xn--ab-j1t',
-            'öbb.at': 'xn--bb-eka.at',
-            'ÖBB.at': 'xn--bb-eka.at',
-            'ȡog.de': 'xn--og-09a.de',
-            '☕.de': 'xn--53h.de',
-            'I♥NY.de': 'xn--iny-zx5a.de',
-            'ＡＢＣ・日本.co.jp': 'xn--abc-rs4b422ycvb.co.jp',
-            '日本｡co｡jp': 'xn--wgv71a.co.jp',
-            '日本｡co．jp': 'xn--wgv71a.co.jp',
-            'x\u0327\u0301.de': 'xn--x-xbb7i.de',
-            'x\u0301\u0327.de': 'xn--x-xbb7i.de',
-            'σόλος.gr': 'xn--wxaikc6b.gr',
-            'Σόλος.gr': 'xn--wxaikc6b.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de': 'xn--wxaikc6b.xn--gr-gtd9a1b0g.de',
-            'عربي.de': 'xn--ngbrx4e.de',
-            'نامهای.de': 'xn--mgba3gch31f.de',
-            'نامه\u200Cای.de': 'xn--mgba3gch31f.de',
+            "faß.de": "fass.de",
+            "fass.de": "fass.de",
+            "xn--fa-hia.de": "xn--fa-hia.de",
+            "fäß.de": "xn--fss-qla.de",
+            "₹.com": "xn--yzg.com",
+            "𑀓.com": "xn--n00d.com",
+            a‌b: "ab",
+            "xn--ab-j1t": "xn--ab-j1t",
+            "öbb.at": "xn--bb-eka.at",
+            "ÖBB.at": "xn--bb-eka.at",
+            "ȡog.de": "xn--og-09a.de",
+            "☕.de": "xn--53h.de",
+            "I♥NY.de": "xn--iny-zx5a.de",
+            "ＡＢＣ・日本.co.jp": "xn--abc-rs4b422ycvb.co.jp",
+            "日本｡co｡jp": "xn--wgv71a.co.jp",
+            "日本｡co．jp": "xn--wgv71a.co.jp",
+            "x\u0327\u0301.de": "xn--x-xbb7i.de",
+            "x\u0301\u0327.de": "xn--x-xbb7i.de",
+            "σόλος.gr": "xn--wxaikc6b.gr",
+            "Σόλος.gr": "xn--wxaikc6b.gr",
+            "ΣΌΛΟΣ.grﻋﺮﺑﻲ.de": "xn--wxaikc6b.xn--gr-gtd9a1b0g.de",
+            "عربي.de": "xn--ngbrx4e.de",
+            "نامهای.de": "xn--mgba3gch31f.de",
+            "نامه\u200Cای.de": "xn--mgba3gch31f.de",
           },
           toAsciiTransitional0: {
-            'xn--bb-eka.at': 'xn--bb-eka.at',
-            'XN--BB-EKA.AT': 'xn--bb-eka.at',
-            'faß.de': 'xn--fa-hia.de',
-            'fass.de': 'fass.de',
-            'xn--fa-hia.de': 'xn--fa-hia.de',
-            'not=std3': 'not=std3',
-            'öbb.at': 'xn--bb-eka.at',
-            'fäß.de': 'xn--f-qfao.de',
-            '₹.com': 'xn--yzg.com',
-            '𑀓.com': 'xn--n00d.com',
-            a‌b: 'xn--ab-j1t',
-            'xn--ab-j1t': 'xn--ab-j1t',
-            'ÖBB.at': 'xn--bb-eka.at',
-            'ȡog.de': 'xn--og-09a.de',
-            '☕.de': 'xn--53h.de',
-            'I♥NY.de': 'xn--iny-zx5a.de',
-            'ＡＢＣ・日本.co.jp': 'xn--abc-rs4b422ycvb.co.jp',
-            '日本｡co｡jp': 'xn--wgv71a.co.jp',
-            '日本｡co．jp': 'xn--wgv71a.co.jp',
-            'x\u0327\u0301.de': 'xn--x-xbb7i.de',
-            'x\u0301\u0327.de': 'xn--x-xbb7i.de',
-            'σόλος.gr': 'xn--wxaijb9b.gr',
-            'Σόλος.gr': 'xn--wxaijb9b.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de': 'xn--wxaikc6b.xn--gr-gtd9a1b0g.de',
-            'عربي.de': 'xn--ngbrx4e.de',
-            'نامهای.de': 'xn--mgba3gch31f.de',
-            'نامه\u200Cای.de': 'xn--mgba3gch31f060k.de',
+            "xn--bb-eka.at": "xn--bb-eka.at",
+            "XN--BB-EKA.AT": "xn--bb-eka.at",
+            "faß.de": "xn--fa-hia.de",
+            "fass.de": "fass.de",
+            "xn--fa-hia.de": "xn--fa-hia.de",
+            "not=std3": "not=std3",
+            "öbb.at": "xn--bb-eka.at",
+            "fäß.de": "xn--f-qfao.de",
+            "₹.com": "xn--yzg.com",
+            "𑀓.com": "xn--n00d.com",
+            a‌b: "xn--ab-j1t",
+            "xn--ab-j1t": "xn--ab-j1t",
+            "ÖBB.at": "xn--bb-eka.at",
+            "ȡog.de": "xn--og-09a.de",
+            "☕.de": "xn--53h.de",
+            "I♥NY.de": "xn--iny-zx5a.de",
+            "ＡＢＣ・日本.co.jp": "xn--abc-rs4b422ycvb.co.jp",
+            "日本｡co｡jp": "xn--wgv71a.co.jp",
+            "日本｡co．jp": "xn--wgv71a.co.jp",
+            "x\u0327\u0301.de": "xn--x-xbb7i.de",
+            "x\u0301\u0327.de": "xn--x-xbb7i.de",
+            "σόλος.gr": "xn--wxaijb9b.gr",
+            "Σόλος.gr": "xn--wxaijb9b.gr",
+            "ΣΌΛΟΣ.grﻋﺮﺑﻲ.de": "xn--wxaikc6b.xn--gr-gtd9a1b0g.de",
+            "عربي.de": "xn--ngbrx4e.de",
+            "نامهای.de": "xn--mgba3gch31f.de",
+            "نامه\u200Cای.de": "xn--mgba3gch31f060k.de",
           },
-          toAsciithrows: [String.fromCodePoint(0xd0000), '\u0080.com'],
-          toAsciiTransitional1throws: ['xn--a.com', '日本⒈co．jp'],
+          toAsciithrows: [String.fromCodePoint(0xd0000), "\u0080.com"],
+          toAsciiTransitional1throws: ["xn--a.com", "日本⒈co．jp"],
           toAsciiTransitional0throws: [
-            '\u0080.com',
-            'xn--a.com',
-            '日本⒈co．jp',
+            "\u0080.com",
+            "xn--a.com",
+            "日本⒈co．jp",
           ],
-          toAsciiUseStd3ASCIIthrows: ['not=std3'],
+          toAsciiUseStd3ASCIIthrows: ["not=std3"],
           toAsciiVerifyDnsLength0: {
-            '': '',
+            "": "",
           },
           toAsciiVerifyDnsLength1throws: [
-            '',
-            'this..is.almost.right',
-            'a.'.repeat(252 / 2) + 'aa',
-            'a'.repeat(64),
+            "",
+            "this..is.almost.right",
+            "a.".repeat(252 / 2) + "aa",
+            "a".repeat(64),
           ],
           toAsciiVerifyDnsLength1throwsnot: [
-            'a.'.repeat(252 / 2) + 'a',
-            'a'.repeat(63),
+            "a.".repeat(252 / 2) + "a",
+            "a".repeat(63),
           ],
           toUnicode: {
-            'öbb.at': 'öbb.at',
-            'Öbb.at': 'öbb.at',
-            'ÖBB.at': 'öbb.at',
-            'O\u0308bb.at': 'öbb.at',
-            'xn--bb-eka.at': 'öbb.at',
-            'xn----5da7e.de': 'ä-ü.de',
-            'faß.de': 'faß.de',
-            'fass.de': 'fass.de',
-            'xn--fa-hia.de': 'faß.de',
-            'not=std3': 'not=std3',
-            '\ud83d\udca9': '\ud83d\udca9',
-            '\ud87e\udcca': '\ud84c\udc0a',
-            '\udb40\udd00\ud87e\udcca': '\ud84c\udc0a',
-            'fäß.de': 'fäß.de',
-            '₹.com': '₹.com',
-            '𑀓.com': '𑀓.com',
-            a‌b: 'a\u200Cb',
-            'xn--ab-j1t': 'a\u200Cb',
-            'ȡog.de': 'ȡog.de',
-            '☕.de': '☕.de',
-            'I♥NY.de': 'i♥ny.de',
-            'ＡＢＣ・日本.co.jp': 'abc・日本.co.jp',
-            '日本｡co｡jp': '日本.co.jp',
-            '日本｡co．jp': '日本.co.jp',
-            'x\u0327\u0301.de': 'x̧́.de',
-            'x\u0301\u0327.de': 'x̧́.de',
-            'σόλος.gr': 'σόλος.gr',
-            'Σόλος.gr': 'σόλος.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de': 'σόλοσ.grعربي.de',
-            'عربي.de': 'عربي.de',
-            'نامهای.de': 'نامهای.de',
-            'نامه\u200Cای.de': 'نامه‌ای.de',
+            "öbb.at": "öbb.at",
+            "Öbb.at": "öbb.at",
+            "ÖBB.at": "öbb.at",
+            "O\u0308bb.at": "öbb.at",
+            "xn--bb-eka.at": "öbb.at",
+            "xn----5da7e.de": "ä-ü.de",
+            "faß.de": "faß.de",
+            "fass.de": "fass.de",
+            "xn--fa-hia.de": "faß.de",
+            "not=std3": "not=std3",
+            "\ud83d\udca9": "\ud83d\udca9",
+            "\ud87e\udcca": "\ud84c\udc0a",
+            "\udb40\udd00\ud87e\udcca": "\ud84c\udc0a",
+            "fäß.de": "fäß.de",
+            "₹.com": "₹.com",
+            "𑀓.com": "𑀓.com",
+            a‌b: "a\u200Cb",
+            "xn--ab-j1t": "a\u200Cb",
+            "ȡog.de": "ȡog.de",
+            "☕.de": "☕.de",
+            "I♥NY.de": "i♥ny.de",
+            "ＡＢＣ・日本.co.jp": "abc・日本.co.jp",
+            "日本｡co｡jp": "日本.co.jp",
+            "日本｡co．jp": "日本.co.jp",
+            "x\u0327\u0301.de": "x̧́.de",
+            "x\u0301\u0327.de": "x̧́.de",
+            "σόλος.gr": "σόλος.gr",
+            "Σόλος.gr": "σόλος.gr",
+            "ΣΌΛΟΣ.grﻋﺮﺑﻲ.de": "σόλοσ.grعربي.de",
+            "عربي.de": "عربي.de",
+            "نامهای.de": "نامهای.de",
+            "نامه\u200Cای.de": "نامه‌ای.de",
           },
           toUnicodethrows: [
             String.fromCodePoint(0xd0000),
-            '\u0080.com',
-            'xn--a.com',
-            '日本⒈co．jp',
+            "\u0080.com",
+            "xn--a.com",
+            "日本⒈co．jp",
           ],
-          toUnicodeUseStd3ASCII1throws: ['not=std3'],
+          toUnicodeUseStd3ASCII1throws: ["not=std3"],
         };
         //TODO xo linting as eslint replacement
 
         // --- method convert
-        eL.innerHTML += '<h2>Method convert</h2>';
+        eL.innerHTML += "<h2>Method convert</h2>";
         let tmp = data.convert;
         Object.keys(tmp).forEach((key) => {
           const val = uts46.convert(key);
           const ok = key === val.IDN && tmp[key] === val.PC;
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val.PC}</div>`;
         });
 
         // --- method toAscii
         eL.innerHTML +=
-          '<h2>Method toAscii (transitionalProcessing: true)</h2>';
+          "<h2>Method toAscii (transitionalProcessing: true)</h2>";
         tmp = data.toAscii;
         Object.keys(tmp).forEach((key) => {
           let val = uts46.toAscii(key, { transitionalProcessing: true });
@@ -180,35 +180,35 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: false)
-        eL.innerHTML += '<h3>... transitionalProcessing: false</h3>';
+        eL.innerHTML += "<h3>... transitionalProcessing: false</h3>";
         tmp = data.toAsciiTransitional0;
         Object.keys(tmp).forEach((key) => {
           const val = uts46.toAscii(key, { transitionalProcessing: false });
           const ok = tmp[key] === val;
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: true)
-        eL.innerHTML += '<h3>... transitionalProcessing: true</h3>';
+        eL.innerHTML += "<h3>... transitionalProcessing: true</h3>";
         tmp = data.toAsciiTransitional1;
         Object.keys(tmp).forEach((key) => {
           const val = uts46.toAscii(key, { transitionalProcessing: true });
           const ok = tmp[key] === val;
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (throws)
-        eL.innerHTML += '<h3>... throws</h3>';
+        eL.innerHTML += "<h3>... throws</h3>";
         tmp = data.toAsciithrows;
         tmp.forEach((val) => {
           let ok;
@@ -221,13 +221,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: true & throws)
-        eL.innerHTML += '<h3>... throws & transitionalProcessing: true</h3>';
+        eL.innerHTML += "<h3>... throws & transitionalProcessing: true</h3>";
         tmp = data.toAsciiTransitional1throws;
         tmp.forEach((val) => {
           let ok;
@@ -240,13 +240,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (transitionalProcessing: false & throws)
-        eL.innerHTML += '<h3>... throws & transitionalProcessing: false</h3>';
+        eL.innerHTML += "<h3>... throws & transitionalProcessing: false</h3>";
         tmp = data.toAsciiTransitional0throws;
         tmp.forEach((val) => {
           let ok;
@@ -259,13 +259,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (useSTD3ASCIIRules: true, throws)
-        eL.innerHTML += '<h3>... throws & useSTD3ASCIIRules: true</h3>';
+        eL.innerHTML += "<h3>... throws & useSTD3ASCIIRules: true</h3>";
         tmp = data.toAsciiUseStd3ASCIIthrows;
         tmp.forEach((val) => {
           let ok;
@@ -275,13 +275,13 @@
           } catch (e) {
             ok = true;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (verifyDNSLength: false)
-        eL.innerHTML += '<h3>... verifyDNSLength: false</h3>';
+        eL.innerHTML += "<h3>... verifyDNSLength: false</h3>";
         tmp = data.toAsciiVerifyDnsLength0;
         Object.keys(tmp).forEach((key) => {
           let val = uts46.toAscii(key, { verifyDNSLength: false });
@@ -292,13 +292,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toAscii (verifyDNSLength: true, throws)
-        eL.innerHTML += '<h3>... throws & verifyDNSLength: true</h3>';
+        eL.innerHTML += "<h3>... throws & verifyDNSLength: true</h3>";
         tmp = data.toAsciiVerifyDnsLength1throws;
         tmp.forEach((val) => {
           let ok;
@@ -311,13 +311,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toAscii (verifyDNSLength: true, throws not)
-        eL.innerHTML += '<h3>... throws not & verifyDNSLength: true</h3>';
+        eL.innerHTML += "<h3>... throws not & verifyDNSLength: true</h3>";
         tmp = data.toAsciiVerifyDnsLength1throwsnot;
         tmp.forEach((val) => {
           let ok;
@@ -327,14 +327,14 @@
           } catch (e) {
             ok = false;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toUnicode
         eL.innerHTML +=
-          '<h2>Method toUnicode (transitionalProcessing: false)</h2>';
+          "<h2>Method toUnicode (transitionalProcessing: false)</h2>";
         tmp = data.toUnicode;
         Object.keys(tmp).forEach((key) => {
           let val = uts46.toUnicode(key, { transitionalProcessing: false });
@@ -345,13 +345,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${key}: ${val}</div>`;
         });
 
         // --- method toUnicode (throws)
-        eL.innerHTML += '<h3>... throws</h3>';
+        eL.innerHTML += "<h3>... throws</h3>";
         tmp = data.toUnicodethrows;
         tmp.forEach((val) => {
           let ok;
@@ -364,13 +364,13 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
 
         // --- method toUnicode (useSTD3ASCIIRules: true, throws)
-        eL.innerHTML += '<h3>... useSTD3ASCIIRules: true & throws</h3>';
+        eL.innerHTML += "<h3>... useSTD3ASCIIRules: true & throws</h3>";
         tmp = data.toUnicodeUseStd3ASCII1throws;
         tmp.forEach((val) => {
           let ok;
@@ -383,8 +383,8 @@
           if (/^[\s ]*$/.test(val)) {
             val = `&quot;${val}&quot;`;
           }
-          eL.innerHTML += `<div class="${ok ? 'ok' : 'err'}"><b>${
-            ok ? 'OK' : 'FAIL'
+          eL.innerHTML += `<div class="${ok ? "ok" : "err"}"><b>${
+            ok ? "OK" : "FAIL"
           }</b> ${val}</div>`;
         });
       }

--- a/test/test-uts46.spec.js
+++ b/test/test-uts46.spec.js
@@ -1,52 +1,52 @@
-'use strict';
+"use strict";
 
-import assert from 'assert';
-import * as uts46 from '../src/index.js';
+import assert from "assert";
+import * as uts46 from "../src/index.js";
 
-suite('toASCII', function () {
-  test('Convert method tests', function () {
+suite("toASCII", function () {
+  test("Convert method tests", function () {
     const d = String.fromCodePoint(0xd0000);
     assert.strict.deepEqual(uts46.convert(d), { IDN: d, PC: d });
-    assert.strict.deepEqual(uts46.convert('öbb.at'), {
-      IDN: 'öbb.at',
-      PC: 'xn--bb-eka.at',
+    assert.strict.deepEqual(uts46.convert("öbb.at"), {
+      IDN: "öbb.at",
+      PC: "xn--bb-eka.at",
     });
-    assert.strict.deepEqual(uts46.convert('xn----5da7e.de'), {
-      IDN: 'ä-ü.de',
-      PC: 'xn----zfa7e.de',
+    assert.strict.deepEqual(uts46.convert("xn----5da7e.de"), {
+      IDN: "ä-ü.de",
+      PC: "xn----zfa7e.de",
     });
-    assert.strict.deepEqual(uts46.convert(['öbb.at', 'faß.de']), {
-      IDN: ['öbb.at', 'faß.de'],
-      PC: ['xn--bb-eka.at', 'xn--fa-hia.de'],
+    assert.strict.deepEqual(uts46.convert(["öbb.at", "faß.de"]), {
+      IDN: ["öbb.at", "faß.de"],
+      PC: ["xn--bb-eka.at", "xn--fa-hia.de"],
     });
   });
-  test('Basic tests', function () {
-    assert.strict.equal(uts46.toAscii('öbb.at'), 'xn--bb-eka.at');
-    assert.strict.equal(uts46.toAscii('xn--bb-eka.at'), 'xn--bb-eka.at');
-    assert.strict.equal(uts46.toAscii('XN--BB-EKA.AT'), 'xn--bb-eka.at');
+  test("Basic tests", function () {
+    assert.strict.equal(uts46.toAscii("öbb.at"), "xn--bb-eka.at");
+    assert.strict.equal(uts46.toAscii("xn--bb-eka.at"), "xn--bb-eka.at");
+    assert.strict.equal(uts46.toAscii("XN--BB-EKA.AT"), "xn--bb-eka.at");
     assert.strict.equal(
-      uts46.toAscii('faß.de', {
+      uts46.toAscii("faß.de", {
         transitionalProcessing: true,
       }),
-      'fass.de',
+      "fass.de",
     );
     assert.strict.equal(
-      uts46.toAscii('faß.de', {
+      uts46.toAscii("faß.de", {
         transitionalProcessing: false,
       }),
-      'xn--fa-hia.de',
+      "xn--fa-hia.de",
     );
     assert.strict.equal(
-      uts46.toAscii('xn--fa-hia.de', {
+      uts46.toAscii("xn--fa-hia.de", {
         transitionalProcessing: true,
       }),
-      'xn--fa-hia.de',
+      "xn--fa-hia.de",
     );
     // Default to not processing STD3 rules (that's what URL.domainToASCII
     // is specifying).
-    assert.strict.equal(uts46.toAscii('not=std3'), 'not=std3');
+    assert.strict.equal(uts46.toAscii("not=std3"), "not=std3");
     assert.throws(function () {
-      uts46.toAscii('not=std3', {
+      uts46.toAscii("not=std3", {
         useSTD3ASCIIRules: true,
       });
     });
@@ -55,79 +55,79 @@ suite('toASCII', function () {
     });
     // Check verify DNS length
     assert.strict.equal(
-      uts46.toAscii('', {
+      uts46.toAscii("", {
         verifyDNSLength: false,
       }),
-      '',
+      "",
     );
     assert.throws(function () {
-      uts46.toAscii('', {
+      uts46.toAscii("", {
         verifyDNSLength: true,
       });
     });
   });
-  test('Verify DNS length parameter', function () {
+  test("Verify DNS length parameter", function () {
     assert.throws(function () {
-      uts46.toAscii('this..is.almost.right', {
+      uts46.toAscii("this..is.almost.right", {
         transitionalProcessing: false,
         verifyDNSLength: true,
       });
     });
     assert.throws(function () {
       // 254 characters
-      uts46.toAscii('a.'.repeat(126) + 'aa', {
+      uts46.toAscii("a.".repeat(126) + "aa", {
         verifyDNSLength: true,
       });
     });
     assert.doesNotThrow(function () {
       // 253 characters
-      uts46.toAscii('a.'.repeat(126) + 'a', {
+      uts46.toAscii("a.".repeat(126) + "a", {
         verifyDNSLength: true,
       });
     });
     assert.throws(function () {
-      uts46.toAscii('a'.repeat(64), {
+      uts46.toAscii("a".repeat(64), {
         verifyDNSLength: true,
       });
     });
     assert.doesNotThrow(function () {
-      uts46.toAscii('a'.repeat(63), {
+      uts46.toAscii("a".repeat(63), {
         verifyDNSLength: true,
       });
     });
     // Default is to not verify it.
-    assert.strict.equal(uts46.toAscii(''), '');
+    assert.strict.equal(uts46.toAscii(""), "");
   });
-  test('Defaults to transitional', function () {
+  test("Defaults to transitional", function () {
     assert.strict.equal(
-      uts46.toAscii('faß.de', { transitionalProcessing: true }),
-      'fass.de',
+      uts46.toAscii("faß.de", { transitionalProcessing: true }),
+      "fass.de",
     );
   });
-  test('Non-BMP characters', function () {
-    assert.strict.equal(uts46.toAscii('\ud83d\udca9'), 'xn--ls8h');
+  test("Non-BMP characters", function () {
+    assert.strict.equal(uts46.toAscii("\ud83d\udca9"), "xn--ls8h");
     // This non-BMP character gets mapped to another non-BMP character.
-    assert.strict.equal(uts46.toAscii('\ud87e\udcca'), 'xn--w60j');
+    assert.strict.equal(uts46.toAscii("\ud87e\udcca"), "xn--w60j");
     // ... and let's throw in a variant selector before it (which gets ignored)!
-    assert.strict.equal(uts46.toAscii('\udb40\udd00\ud87e\udcca'), 'xn--w60j');
+    assert.strict.equal(uts46.toAscii("\udb40\udd00\ud87e\udcca"), "xn--w60j");
   });
 });
 
-suite('toUnicode', function () {
-  test('Basic tests', function () {
-    assert.strict.equal(uts46.toUnicode('öbb.at'), 'öbb.at');
-    assert.strict.equal(uts46.toUnicode('Öbb.at'), 'öbb.at');
-    assert.strict.equal(uts46.toUnicode('O\u0308bb.at'), 'öbb.at');
-    assert.strict.equal(uts46.toUnicode('xn--bb-eka.at'), 'öbb.at');
-    assert.strict.equal(uts46.toUnicode('xn----5da7e.de'), 'ä-ü.de');
-    assert.strict.equal(uts46.toUnicode('faß.de'), 'faß.de');
-    assert.strict.equal(uts46.toUnicode('fass.de'), 'fass.de');
-    assert.strict.equal(uts46.toUnicode('xn--fa-hia.de'), 'faß.de');
+suite("toUnicode", function () {
+  test("Basic tests", function () {
+    assert.strict.equal(uts46.toUnicode("öbb.at"), "öbb.at");
+    assert.strict.equal(uts46.toUnicode("Öbb.at"), "öbb.at");
+    assert.strict.equal(uts46.toUnicode("O\u0308bb.at"), "öbb.at");
+    assert.strict.equal(uts46.toUnicode("xn--bb-eka.at"), "öbb.at");
+    assert.strict.equal(uts46.toUnicode("xn----5da7e.de"), "ä-ü.de");
+    assert.strict.equal(uts46.toUnicode("faß.de"), "faß.de");
+    assert.strict.equal(uts46.toUnicode("fass.de"), "fass.de");
+    assert.strict.equal(uts46.toUnicode("xn--fa-hia.de"), "faß.de");
     // Default to not processing STD3 rules (that's what URL.domainToASCII
     // is specifying).
-    assert.strict.equal(uts46.toUnicode('not=std3'), 'not=std3');
+    assert.strict.equal(uts46.toUnicode("not=std3"), "not=std3");
     assert.throws(function () {
-      uts46.toUnicode('not=std3', {
+      uts46.toUnicode("not=std3", {
         useSTD3ASCIIRules: true,
       });
     });
@@ -135,140 +135,140 @@ suite('toUnicode', function () {
       uts46.toUnicode(String.fromCodePoint(0xd0000));
     });
   });
-  test('Non-BMP characters', function () {
-    assert.strict.equal(uts46.toUnicode('\ud83d\udca9'), '\ud83d\udca9');
+  test("Non-BMP characters", function () {
+    assert.strict.equal(uts46.toUnicode("\ud83d\udca9"), "\ud83d\udca9");
     // This non-BMP character gets mapped to another non-BMP character.
-    assert.strict.equal(uts46.toUnicode('\ud87e\udcca'), '\ud84c\udc0a');
+    assert.strict.equal(uts46.toUnicode("\ud87e\udcca"), "\ud84c\udc0a");
     // ... and let's throw in a variant selector before it (which gets ignored)!
     assert.strict.equal(
-      uts46.toUnicode('\udb40\udd00\ud87e\udcca'),
-      '\ud84c\udc0a',
+      uts46.toUnicode("\udb40\udd00\ud87e\udcca"),
+      "\ud84c\udc0a",
     );
   });
 });
 
-suite('unicode.org', function () {
-  test('Unicode Utilities: Internationalized Domain Names (IDN)', function () {
+suite("unicode.org", function () {
+  test("Unicode Utilities: Internationalized Domain Names (IDN)", function () {
     // http://unicode.org/cldr/utility/idna.jsp
     // NOTE: some of the results below need further research as they are marked
     // as error cases on the web page but working here (or otherwise)
 
     // fass.de
-    assert.strict.equal(uts46.toUnicode('fass.de'), 'fass.de');
+    assert.strict.equal(uts46.toUnicode("fass.de"), "fass.de");
     assert.strict.equal(
-      uts46.toAscii('fass.de', {
+      uts46.toAscii("fass.de", {
         transitionalProcessing: true,
       }),
-      'fass.de',
+      "fass.de",
     );
     assert.strict.equal(
-      uts46.toAscii('fass.de', {
+      uts46.toAscii("fass.de", {
         transitionalProcessing: false,
       }),
-      'fass.de',
+      "fass.de",
     );
 
     // faß.de
-    assert.strict.equal(uts46.toUnicode('faß.de'), 'faß.de');
+    assert.strict.equal(uts46.toUnicode("faß.de"), "faß.de");
     assert.strict.equal(
-      uts46.toAscii('faß.de', {
+      uts46.toAscii("faß.de", {
         transitionalProcessing: true,
       }),
-      'fass.de',
+      "fass.de",
     );
     assert.strict.equal(
-      uts46.toAscii('faß.de', {
+      uts46.toAscii("faß.de", {
         transitionalProcessing: false,
       }),
-      'xn--fa-hia.de',
+      "xn--fa-hia.de",
     );
 
     // fäß.de
-    assert.strict.equal(uts46.toUnicode('fäß.de'), 'fäß.de');
+    assert.strict.equal(uts46.toUnicode("fäß.de"), "fäß.de");
     assert.strict.equal(
-      uts46.toAscii('fäß.de', {
+      uts46.toAscii("fäß.de", {
         transitionalProcessing: true,
       }),
-      'xn--fss-qla.de',
+      "xn--fss-qla.de",
     );
     assert.strict.equal(
-      uts46.toAscii('fäß.de', {
+      uts46.toAscii("fäß.de", {
         transitionalProcessing: false,
       }),
-      'xn--f-qfao.de',
+      "xn--f-qfao.de",
     );
 
     // xn--fa-hia.de
-    assert.strict.equal(uts46.toUnicode('xn--fa-hia.de'), 'faß.de');
+    assert.strict.equal(uts46.toUnicode("xn--fa-hia.de"), "faß.de");
     assert.strict.equal(
-      uts46.toAscii('xn--fa-hia.de', {
+      uts46.toAscii("xn--fa-hia.de", {
         transitionalProcessing: true,
       }),
-      'xn--fa-hia.de',
+      "xn--fa-hia.de",
     );
     assert.strict.equal(
-      uts46.toAscii('xn--fa-hia.de', {
+      uts46.toAscii("xn--fa-hia.de", {
         transitionalProcessing: false,
       }),
-      'xn--fa-hia.de',
+      "xn--fa-hia.de",
     );
 
     // ₹.com
-    assert.strict.equal(uts46.toUnicode('₹.com'), '₹.com'); // no error thrown
+    assert.strict.equal(uts46.toUnicode("₹.com"), "₹.com"); // no error thrown
     assert.strict.equal(
-      uts46.toAscii('₹.com', {
+      uts46.toAscii("₹.com", {
         transitionalProcessing: true,
       }),
-      'xn--yzg.com',
+      "xn--yzg.com",
     );
     assert.strict.equal(
-      uts46.toAscii('₹.com', {
+      uts46.toAscii("₹.com", {
         transitionalProcessing: false,
       }),
-      'xn--yzg.com',
+      "xn--yzg.com",
     ); // no error thrown
 
     // 𑀓.com
-    assert.strict.equal(uts46.toUnicode('𑀓.com'), '𑀓.com'); // no error thrown
+    assert.strict.equal(uts46.toUnicode("𑀓.com"), "𑀓.com"); // no error thrown
     assert.strict.equal(
-      uts46.toAscii('𑀓.com', {
+      uts46.toAscii("𑀓.com", {
         transitionalProcessing: true,
       }),
-      'xn--n00d.com',
+      "xn--n00d.com",
     );
     assert.strict.equal(
-      uts46.toAscii('𑀓.com', {
+      uts46.toAscii("𑀓.com", {
         transitionalProcessing: false,
       }),
-      'xn--n00d.com',
+      "xn--n00d.com",
     );
 
     // \u0080.com
     assert.throws(function () {
-      uts46.toUnicode('\u0080.com');
+      uts46.toUnicode("\u0080.com");
     });
     assert.throws(function () {
-      uts46.toAscii('\u0080.com', {
+      uts46.toAscii("\u0080.com", {
         transitionalProcessing: true,
       });
     });
     assert.throws(function () {
-      uts46.toAscii('\u0080.com', {
+      uts46.toAscii("\u0080.com", {
         transitionalProcessing: false,
       });
     });
 
     // xn--a.com [might be wrong one compare results in web]
     assert.throws(function () {
-      uts46.toUnicode('xn--a.com');
+      uts46.toUnicode("xn--a.com");
     });
     assert.throws(function () {
-      uts46.toAscii('xn--a.com', {
+      uts46.toAscii("xn--a.com", {
         transitionalProcessing: true,
       });
     });
     assert.throws(function () {
-      uts46.toAscii('xn--a.com', {
+      uts46.toAscii("xn--a.com", {
         transitionalProcessing: false,
       });
     });
@@ -276,316 +276,316 @@ suite('unicode.org', function () {
     /* jshint -W100 */
     // a‌b
     assert.strict.equal(
-      uts46.toUnicode('a‌b', {
+      uts46.toUnicode("a‌b", {
         transitionalProcessing: false,
       }),
-      'a\u200Cb',
+      "a\u200Cb",
     ); // no error thrown
     assert.strict.equal(
-      uts46.toAscii('a‌b', {
+      uts46.toAscii("a‌b", {
         transitionalProcessing: true,
       }),
-      'ab',
+      "ab",
     );
     assert.strict.equal(
-      uts46.toAscii('a‌b', {
+      uts46.toAscii("a‌b", {
         transitionalProcessing: false,
       }),
-      'xn--ab-j1t',
+      "xn--ab-j1t",
     );
     /* jshint +W100 */
 
     // xn--ab-j1t
-    assert.strict.equal(uts46.toUnicode('xn--ab-j1t'), 'a\u200Cb'); // no error thrown
+    assert.strict.equal(uts46.toUnicode("xn--ab-j1t"), "a\u200Cb"); // no error thrown
     assert.strict.equal(
-      uts46.toAscii('xn--ab-j1t', {
+      uts46.toAscii("xn--ab-j1t", {
         // no error thrown
         transitionalProcessing: true,
       }),
-      'xn--ab-j1t',
+      "xn--ab-j1t",
     );
     assert.strict.equal(
-      uts46.toAscii('xn--ab-j1t', {
+      uts46.toAscii("xn--ab-j1t", {
         transitionalProcessing: false,
       }),
-      'xn--ab-j1t',
+      "xn--ab-j1t",
     );
 
     // öbb.at
-    assert.strict.equal(uts46.toUnicode('öbb.at'), 'öbb.at');
+    assert.strict.equal(uts46.toUnicode("öbb.at"), "öbb.at");
     assert.strict.equal(
-      uts46.toAscii('öbb.at', {
+      uts46.toAscii("öbb.at", {
         transitionalProcessing: true,
       }),
-      'xn--bb-eka.at',
+      "xn--bb-eka.at",
     );
     assert.strict.equal(
-      uts46.toAscii('öbb.at', {
+      uts46.toAscii("öbb.at", {
         transitionalProcessing: false,
       }),
-      'xn--bb-eka.at',
+      "xn--bb-eka.at",
     );
 
     // ÖBB.at
-    assert.strict.equal(uts46.toUnicode('ÖBB.at'), 'öbb.at');
+    assert.strict.equal(uts46.toUnicode("ÖBB.at"), "öbb.at");
     assert.strict.equal(
-      uts46.toAscii('ÖBB.at', {
+      uts46.toAscii("ÖBB.at", {
         transitionalProcessing: true,
       }),
-      'xn--bb-eka.at',
+      "xn--bb-eka.at",
     );
     assert.strict.equal(
-      uts46.toAscii('ÖBB.at', {
+      uts46.toAscii("ÖBB.at", {
         transitionalProcessing: false,
       }),
-      'xn--bb-eka.at',
+      "xn--bb-eka.at",
     );
 
     // ȡog.de
-    assert.strict.equal(uts46.toUnicode('ȡog.de'), 'ȡog.de');
+    assert.strict.equal(uts46.toUnicode("ȡog.de"), "ȡog.de");
     assert.strict.equal(
-      uts46.toAscii('ȡog.de', {
+      uts46.toAscii("ȡog.de", {
         transitionalProcessing: true,
       }),
-      'xn--og-09a.de',
+      "xn--og-09a.de",
     );
     assert.strict.equal(
-      uts46.toAscii('ȡog.de', {
+      uts46.toAscii("ȡog.de", {
         transitionalProcessing: false,
       }),
-      'xn--og-09a.de',
+      "xn--og-09a.de",
     );
 
     // ☕.de
-    assert.strict.equal(uts46.toUnicode('☕.de'), '☕.de');
+    assert.strict.equal(uts46.toUnicode("☕.de"), "☕.de");
     assert.strict.equal(
-      uts46.toAscii('☕.de', {
+      uts46.toAscii("☕.de", {
         transitionalProcessing: true,
       }),
-      'xn--53h.de',
+      "xn--53h.de",
     );
     assert.strict.equal(
-      uts46.toAscii('☕.de', {
+      uts46.toAscii("☕.de", {
         transitionalProcessing: false,
       }),
-      'xn--53h.de',
+      "xn--53h.de",
     );
 
     // I♥NY.de
-    assert.strict.equal(uts46.toUnicode('I♥NY.de'), 'i♥ny.de');
+    assert.strict.equal(uts46.toUnicode("I♥NY.de"), "i♥ny.de");
     assert.strict.equal(
-      uts46.toAscii('I♥NY.de', {
+      uts46.toAscii("I♥NY.de", {
         transitionalProcessing: true,
       }),
-      'xn--iny-zx5a.de',
+      "xn--iny-zx5a.de",
     );
     assert.strict.equal(
-      uts46.toAscii('I♥NY.de', {
+      uts46.toAscii("I♥NY.de", {
         transitionalProcessing: false,
       }),
-      'xn--iny-zx5a.de',
+      "xn--iny-zx5a.de",
     );
 
     // ＡＢＣ・日本.co.jp
     assert.strict.equal(
-      uts46.toUnicode('ＡＢＣ・日本.co.jp'),
-      'abc・日本.co.jp',
+      uts46.toUnicode("ＡＢＣ・日本.co.jp"),
+      "abc・日本.co.jp",
     );
     assert.strict.equal(
-      uts46.toAscii('ＡＢＣ・日本.co.jp', {
+      uts46.toAscii("ＡＢＣ・日本.co.jp", {
         transitionalProcessing: true,
       }),
-      'xn--abc-rs4b422ycvb.co.jp',
+      "xn--abc-rs4b422ycvb.co.jp",
     );
     assert.strict.equal(
-      uts46.toAscii('ＡＢＣ・日本.co.jp', {
+      uts46.toAscii("ＡＢＣ・日本.co.jp", {
         transitionalProcessing: false,
       }),
-      'xn--abc-rs4b422ycvb.co.jp',
+      "xn--abc-rs4b422ycvb.co.jp",
     );
 
     // 日本｡co｡jp
-    assert.strict.equal(uts46.toUnicode('日本｡co｡jp'), '日本.co.jp');
+    assert.strict.equal(uts46.toUnicode("日本｡co｡jp"), "日本.co.jp");
     assert.strict.equal(
-      uts46.toAscii('日本｡co｡jp', {
+      uts46.toAscii("日本｡co｡jp", {
         transitionalProcessing: true,
       }),
-      'xn--wgv71a.co.jp',
+      "xn--wgv71a.co.jp",
     );
     assert.strict.equal(
-      uts46.toAscii('日本｡co｡jp', {
+      uts46.toAscii("日本｡co｡jp", {
         transitionalProcessing: false,
       }),
-      'xn--wgv71a.co.jp',
+      "xn--wgv71a.co.jp",
     );
 
     // 日本｡co．jp
-    assert.strict.equal(uts46.toUnicode('日本｡co．jp'), '日本.co.jp');
+    assert.strict.equal(uts46.toUnicode("日本｡co．jp"), "日本.co.jp");
     assert.strict.equal(
-      uts46.toAscii('日本｡co．jp', {
+      uts46.toAscii("日本｡co．jp", {
         transitionalProcessing: true,
       }),
-      'xn--wgv71a.co.jp',
+      "xn--wgv71a.co.jp",
     );
     assert.strict.equal(
-      uts46.toAscii('日本｡co．jp', {
+      uts46.toAscii("日本｡co．jp", {
         transitionalProcessing: false,
       }),
-      'xn--wgv71a.co.jp',
+      "xn--wgv71a.co.jp",
     );
 
     // 日本⒈co．jp
     assert.throws(function () {
-      uts46.toUnicode('日本⒈co．jp');
+      uts46.toUnicode("日本⒈co．jp");
     });
     assert.throws(function () {
-      uts46.toAscii('日本⒈co．jp', {
+      uts46.toAscii("日本⒈co．jp", {
         transitionalProcessing: true,
       });
     });
     assert.throws(function () {
-      uts46.toAscii('日本⒈co．jp', {
+      uts46.toAscii("日本⒈co．jp", {
         transitionalProcessing: false,
       });
     });
 
     // x\u0327\u0301.de
-    assert.strict.equal(uts46.toUnicode('x\u0327\u0301.de'), 'x̧́.de');
+    assert.strict.equal(uts46.toUnicode("x\u0327\u0301.de"), "x̧́.de");
     assert.strict.equal(
-      uts46.toAscii('x\u0327\u0301.de', {
+      uts46.toAscii("x\u0327\u0301.de", {
         transitionalProcessing: true,
       }),
-      'xn--x-xbb7i.de',
+      "xn--x-xbb7i.de",
     );
     assert.strict.equal(
-      uts46.toAscii('x\u0327\u0301.de', {
+      uts46.toAscii("x\u0327\u0301.de", {
         transitionalProcessing: false,
       }),
-      'xn--x-xbb7i.de',
+      "xn--x-xbb7i.de",
     );
 
     // x\u0301\u0327.de
-    assert.strict.equal(uts46.toUnicode('x\u0301\u0327.de'), 'x̧́.de');
+    assert.strict.equal(uts46.toUnicode("x\u0301\u0327.de"), "x̧́.de");
     assert.strict.equal(
-      uts46.toAscii('x\u0301\u0327.de', {
+      uts46.toAscii("x\u0301\u0327.de", {
         transitionalProcessing: true,
       }),
-      'xn--x-xbb7i.de',
+      "xn--x-xbb7i.de",
     );
     assert.strict.equal(
-      uts46.toAscii('x\u0301\u0327.de', {
+      uts46.toAscii("x\u0301\u0327.de", {
         transitionalProcessing: false,
       }),
-      'xn--x-xbb7i.de',
+      "xn--x-xbb7i.de",
     );
 
     // σόλος.gr
     assert.strict.equal(
-      uts46.toUnicode('σόλος.gr', {
+      uts46.toUnicode("σόλος.gr", {
         transitionalProcessing: false,
       }),
-      'σόλος.gr',
+      "σόλος.gr",
     );
     assert.strict.equal(
-      uts46.toAscii('σόλος.gr', {
+      uts46.toAscii("σόλος.gr", {
         transitionalProcessing: true,
       }),
-      'xn--wxaikc6b.gr',
+      "xn--wxaikc6b.gr",
     );
     assert.strict.equal(
-      uts46.toAscii('σόλος.gr', {
+      uts46.toAscii("σόλος.gr", {
         transitionalProcessing: false,
       }),
-      'xn--wxaijb9b.gr',
+      "xn--wxaijb9b.gr",
     );
 
     // Σόλος.gr
     assert.strict.equal(
-      uts46.toUnicode('Σόλος.gr', {
+      uts46.toUnicode("Σόλος.gr", {
         transitionalProcessing: false,
       }),
-      'σόλος.gr',
+      "σόλος.gr",
     );
     assert.strict.equal(
-      uts46.toAscii('Σόλος.gr', {
+      uts46.toAscii("Σόλος.gr", {
         transitionalProcessing: true,
       }),
-      'xn--wxaikc6b.gr',
+      "xn--wxaikc6b.gr",
     );
     assert.strict.equal(
-      uts46.toAscii('Σόλος.gr', {
+      uts46.toAscii("Σόλος.gr", {
         transitionalProcessing: false,
       }),
-      'xn--wxaijb9b.gr',
+      "xn--wxaijb9b.gr",
     ); // might be wrong
 
     // ΣΌΛΟΣ.grﻋﺮﺑﻲ.de
-    assert.strict.equal(uts46.toUnicode('ΣΌΛΟΣ.grﻋﺮﺑﻲ.de'), 'σόλοσ.grعربي.de');
+    assert.strict.equal(uts46.toUnicode("ΣΌΛΟΣ.grﻋﺮﺑﻲ.de"), "σόλοσ.grعربي.de");
     assert.strict.equal(
-      uts46.toAscii('ΣΌΛΟΣ.grﻋﺮﺑﻲ.de', {
+      uts46.toAscii("ΣΌΛΟΣ.grﻋﺮﺑﻲ.de", {
         transitionalProcessing: true,
       }),
-      'xn--wxaikc6b.xn--gr-gtd9a1b0g.de',
+      "xn--wxaikc6b.xn--gr-gtd9a1b0g.de",
     );
     assert.strict.equal(
-      uts46.toAscii('ΣΌΛΟΣ.grﻋﺮﺑﻲ.de', {
+      uts46.toAscii("ΣΌΛΟΣ.grﻋﺮﺑﻲ.de", {
         transitionalProcessing: false,
       }),
-      'xn--wxaikc6b.xn--gr-gtd9a1b0g.de',
+      "xn--wxaikc6b.xn--gr-gtd9a1b0g.de",
     ); // might be wrong
 
     // عربي.de
-    assert.strict.equal(uts46.toUnicode('عربي.de'), 'عربي.de');
+    assert.strict.equal(uts46.toUnicode("عربي.de"), "عربي.de");
     assert.strict.equal(
-      uts46.toAscii('عربي.de', {
+      uts46.toAscii("عربي.de", {
         transitionalProcessing: true,
       }),
-      'xn--ngbrx4e.de',
+      "xn--ngbrx4e.de",
     );
     assert.strict.equal(
-      uts46.toAscii('عربي.de', {
+      uts46.toAscii("عربي.de", {
         transitionalProcessing: false,
       }),
-      'xn--ngbrx4e.de',
+      "xn--ngbrx4e.de",
     );
 
     // نامهای.de
-    assert.strict.equal(uts46.toUnicode('نامهای.de'), 'نامهای.de');
+    assert.strict.equal(uts46.toUnicode("نامهای.de"), "نامهای.de");
     assert.strict.equal(
-      uts46.toAscii('نامهای.de', {
+      uts46.toAscii("نامهای.de", {
         transitionalProcessing: true,
       }),
-      'xn--mgba3gch31f.de',
+      "xn--mgba3gch31f.de",
     );
     assert.strict.equal(
-      uts46.toAscii('نامهای.de', {
+      uts46.toAscii("نامهای.de", {
         transitionalProcessing: false,
       }),
-      'xn--mgba3gch31f.de',
+      "xn--mgba3gch31f.de",
     );
 
     // نامه\u200Cای.de
     /* jshint -W100 */
-    assert.strict.equal(uts46.toUnicode('نامه\u200Cای.de'), 'نامه‌ای.de');
+    assert.strict.equal(uts46.toUnicode("نامه\u200Cای.de"), "نامه‌ای.de");
     assert.strict.equal(
-      uts46.toAscii('نامه\u200Cای.de', {
+      uts46.toAscii("نامه\u200Cای.de", {
         transitionalProcessing: true,
       }),
-      'xn--mgba3gch31f.de',
+      "xn--mgba3gch31f.de",
     );
     assert.strict.equal(
-      uts46.toAscii('نامه\u200Cای.de', {
+      uts46.toAscii("نامه\u200Cای.de", {
         transitionalProcessing: false,
       }),
-      'xn--mgba3gch31f060k.de',
+      "xn--mgba3gch31f060k.de",
     );
     /* jshint +W100 */
 
     // common emojis
-    assert.strict.equal(uts46.toAscii('😂'), 'xn--g28h');
-    assert.strict.equal(uts46.toAscii('🫡'), 'xn--229h');
+    assert.strict.equal(uts46.toAscii("😂"), "xn--g28h");
+    assert.strict.equal(uts46.toAscii("🫡"), "xn--229h");
 
-    assert.strict.equal(uts46.toUnicode('xn--g28h'), '😂');
-    assert.strict.equal(uts46.toUnicode('xn--229h'), '🫡');
+    assert.strict.equal(uts46.toUnicode("xn--g28h"), "😂");
+    assert.strict.equal(uts46.toUnicode("xn--229h"), "🫡");
   });
 });

--- a/vite.config.coverage.js
+++ b/vite.config.coverage.js
@@ -1,11 +1,11 @@
 // vite.config.coverage.js
-import { defineConfig } from 'vite';
+import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
-    root: 'coverage',
+    root: "coverage",
     port: 8080,
     strictPort: true,
-    open: '/coverage/index.html',
+    open: "/coverage/index.html",
   },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,11 @@
 // vite.config.js
-import { defineConfig } from 'vite';
+import { defineConfig } from "vite";
 
 export default defineConfig({
   server: {
-    root: 'test',
+    root: "test",
     port: 8080,
     strictPort: true,
-    open: '/test/index.html',
+    open: "/test/index.html",
   },
 });


### PR DESCRIPTION
Jira: [RSRMID-3042](https://centralnic.atlassian.net/browse/RSRMID-3042)

Completes the fleet change started in [template#9](https://github.com/centralnicgroup-opensource/rtldev-middleware-template/pull/9) and [php-sdk#334](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/pull/334): no prettier config anywhere, everything on prettier's defaults.

This repository kept its config inline in `package.json`, and its only real deviation was `singleQuote: true` — `tabWidth: 2` and `trailingComma: "all"` already matched the 3.9.6 defaults.

Unlike the other two, removal here is **not** formatting-neutral, and that is the point. idna-uts46 was the only repository in the fleet actually formatting differently; the other two were carrying files that had stopped meaning anything.

## End state

| | prettier config | `.editorconfig` | Effective |
| --- | --- | --- | --- |
| node-sdk | none | none | defaults |
| **idna-uts46 (this PR)** | **none** | none | **defaults** |
| template | none (#9) | `[*]`=2, `[*.md]`=2 | defaults |
| php-sdk | none (#334) | `[*]`=4, `[*.md]`=2 | defaults for MD/YAML/JSON |

No `.editorconfig` here, so nothing shadows the defaults — that step was only needed where a prettier config had been overriding `indent_size`.

## Scope

17 files, ~660 lines, all quote flips. That includes YAML, since `singleQuote` applies there too, so the `.github` files return to double quotes after briefly flipping to single when `.prettierignore` stopped excluding them.

## No consumer-visible effect — measured, not assumed

- **All three dist artifacts rebuild byte-identical**, sha256 and byte count unchanged, browser bundle included at **222209 bytes**. Terser normalises quoting during minification, so source quote style cannot reach the published output: the shipped bundle already carries 12363 double quotes against 3 single ones while being built from single-quoted source.
- **The unicode mapping table is not in this repository.** It comes from `tr46` under `node_modules`, which prettier never reads, so no codepoint, escape or payload can be affected. Your source is ~0.4% of the 217 KiB bundle; the rest is tr46's expanded tables.
- The only non-ASCII in `src/` is in the CLI usage **template literal**, which backticks make immune to the quote setting regardless.
- `src/cli.js` is not bundled at all — rollup's input is `src/index.js` only. Of the 17 touched files, exactly one feeds the browser artifact, with a two-line diff.

## Blame churn

The reformat is listed in `.git-blame-ignore-revs`. Verified on `test/test-uts46.spec.js:25`:

```
without ignore file: e537fe67   <- the reformat commit
with    ignore file: 205f1f2e   <- the real author
```

Github honours the file automatically; locally it is `git config blame.ignoreRevsFile .git-blame-ignore-revs` once, which CONTRIBUTING now documents.

## Test plan

- `pnpm test` — 25 passing.
- `pnpm lint`, `pnpm prettier` — clean.
- `dist/` rebuilds byte-identical, so it does not even appear in the diff.

`style` and `build` types, so semantic-release cuts no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-3042]: https://centralnic.atlassian.net/browse/RSRMID-3042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ