### PR TITLE
build(blame): record the sha the reformat actually landed as

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,7 +3,10 @@
 # Github honours this file automatically. Locally, opt in once with:
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
 #
-# Add a commit here only if it changes formatting and nothing else.
+# Add a commit here only if it changes formatting and nothing else, and record the
+# sha it has *after* it lands on main. This repository rebase-merges, so a pull
+# request's commits get new shas when they are merged, and a sha taken from the
+# branch beforehand names a commit that is not on main and silently matches nothing.
 
 # style(prettier): drop the prettier config in favour of defaults
-e537fe6779728620e39c52c30e5c9448c5f223cc
+8cab1ec0cf39a516bf9cea2239a42781097986e3


### PR DESCRIPTION
Jira: [RSRMID-3042](https://centralnic.atlassian.net/browse/RSRMID-3042)

Follow-up defect fix to [#1049](https://github.com/centralnicgroup-opensource/rtldev-middleware-idna-uts46/pull/1049): **the blame-ignore file it added did not work on `main`.**

`.git-blame-ignore-revs` recorded `e537fe6`, the sha the reformat had on the PR branch. This repository rebase-merges, so that commit was rewritten on the way in and landed as `8cab1ec`. A sha that is not reachable from `main` matches nothing — and git reports no error for it, so the file looked fine while blame carried on pointing at the reformat.

Verified on `main` before the fix:

```
without ignore file: 8cab1ec0
with    ignore file: 8cab1ec0   <- no effect
```

And after:

```
without ignore file: 8cab1ec0   (the reformat)
with    ignore file: 205f1f2e   (the real author)
```

The file now also states the rule that caused this: take the sha **after** it lands on `main`, not from the branch. Anyone adding the next entry would otherwise hit exactly the same trap, since it fails silently.

Worth noting for the other repositories: this only bites where a reformat is recorded, so template and php-sdk are unaffected — their changes were formatting-neutral and neither has a `.git-blame-ignore-revs`.

## Test plan

Blame verified against the real `main` history, shown above. No source or formatting change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-3042]: https://centralnic.atlassian.net/browse/RSRMID-3042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ